### PR TITLE
Fix CardInstance interface method args

### DIFF
--- a/src/services/combatService.ts
+++ b/src/services/combatService.ts
@@ -362,7 +362,7 @@ export class CardInstanceImpl implements CardInstance {
    * Cette méthode est appelée après chaque modification des altérations ou tags,
    * et actualise les statistiques d'attaque, défense et autres attributs modifiables.
    */
-  public recalculateTemporaryStats(allCardsInPlay: CardInstance[], gameState: any): void {
+  public recalculateTemporaryStats(allCardsInPlay: CardInstance[] = [], gameState: any = {}): void {
     // 1. Réinitialiser les statistiques aux valeurs de base de la définition de la carte
     this.temporaryStats = {
       attack: (this.cardDefinition.properties as any).attack || 0,

--- a/src/tests/services/cardCrudOperations.test.ts
+++ b/src/tests/services/cardCrudOperations.test.ts
@@ -106,10 +106,13 @@ describe('Card CRUD Operations', () => {
     const newCardData: CardInsert = {
       name: 'New Test Card',
       description: 'A new card for testing',
-      type: 'sort',
+      // Utiliser un type valide afin d'éviter une erreur de compilation
+      type: 'action',
       rarity: 'rare',
       properties: { mana_cost: 4 },
       summon_cost: 0, // Assuming 0 for sort type or if not applicable
+      image: null,
+      passive_effect: null,
       is_wip: true,
       is_crap: false,
     };

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -122,7 +122,9 @@ export interface CardInstance {
   resetForNextTurn: () => void;
   
   // Recalcule les statistiques temporaires basées sur les altérations actives
-  recalculateTemporaryStats: () => void;
+  // Les paramètres sont optionnels pour permettre d'utiliser la méthode sans
+  // contexte supplémentaire dans les tests ou les appels simples.
+  recalculateTemporaryStats: (allCardsInPlay?: CardInstance[], gameState?: any) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- adjust `CardInstance` interface to accept optional params for `recalculateTemporaryStats`
- provide defaults in `CardInstanceImpl` implementation
- use a valid card type in CRUD tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e71aa710832bb090754de9bcba91