### PR TITLE
Remove JWT secret fallback

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -7,7 +7,11 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const router = Router();
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+const JWT_SECRET = process.env.JWT_SECRET;
+
+if (!JWT_SECRET) {
+  throw new Error('Missing JWT_SECRET environment variable');
+}
 
 const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
 const supabaseKey = process.env.REACT_APP_SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- drop default JWT secret
- error clearly if JWT_SECRET is missing

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: ERESOLVE dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841edf532a4832ba1f19bf93bc4567e