### PR TITLE
Ajout module de simulation de parties

### DIFF
--- a/src/simulation/__tests__/gameSimulator.test.ts
+++ b/src/simulation/__tests__/gameSimulator.test.ts
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+jest.mock('../../utils/dataService', () => ({
+  simulationResultsService: {
+    create: jest.fn(() => Promise.resolve({}))
+  }
+}));
+
+import { simulateGame } from '../gameSimulator';
+import { simulationResultsService } from '../../utils/dataService';
+
+const { simulationResultsService: mockedService } = jest.requireMock('../../utils/dataService') as {
+  simulationResultsService: { create: jest.Mock }
+};
+
+describe('simulateGame', () => {
+  it('enregistre le resultat dans simulationResultsService', async () => {
+    await simulateGame({ deckId: 'deck1', opponentDeckId: 'deck2' });
+    expect(mockedService.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/simulation/gameSimulator.ts
+++ b/src/simulation/gameSimulator.ts
@@ -1,0 +1,37 @@
+import { simulationResultsService } from '../utils/dataService';
+import type { Database } from '../types/database.types';
+
+export type SimulationType = 'training' | 'performance' | 'metrics';
+
+export interface SimulationOptions {
+  deckId: string;
+  opponentDeckId: string;
+  simulationType?: SimulationType;
+}
+
+export interface SimulationResult {
+  winner: string;
+  turns: number;
+}
+
+/**
+ * Lance une partie automatique simplifiée entre deux decks.
+ * Le vainqueur et le nombre de tours sont déterminés aléatoirement.
+ * Le résultat est sauvegardé via simulationResultsService.create.
+ */
+export async function simulateGame({ deckId, opponentDeckId, simulationType = 'training' }: SimulationOptions): Promise<SimulationResult> {
+  // Déterminer aléatoirement un nombre de tours et le gagnant
+  const turns = Math.floor(Math.random() * 10) + 1;
+  const winner = Math.random() > 0.5 ? deckId : opponentDeckId;
+
+  // Sauvegarder le résultat de la simulation
+  await simulationResultsService.create({
+    simulation_type: simulationType,
+    deck_id: deckId,
+    opponent_deck_id: opponentDeckId,
+    result: { won: winner === deckId, turns } as Database['public']['Tables']['simulation_results']['Row']['result'],
+    metadata: {}
+  });
+
+  return { winner, turns };
+}


### PR DESCRIPTION
## Summary
- ajouter `simulateGame` qui simule une partie simplifiée et sauvegarde le résultat
- créer des tests unitaires pour vérifier l'enregistrement du résultat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fb4373d4832b96d3ae3511600f2f