### PR TITLE
Add combat rule logging viewer

### DIFF
--- a/src/components/CombatLogViewer.css
+++ b/src/components/CombatLogViewer.css
@@ -1,0 +1,22 @@
+.combat-log-viewer {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  max-width: 250px;
+  z-index: 1000;
+}
+
+.combat-log-viewer ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.combat-log-viewer li {
+  margin-bottom: 0.25rem;
+}

--- a/src/components/CombatLogViewer.tsx
+++ b/src/components/CombatLogViewer.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { combatLogService, CombatLogEvent } from '../services/combatLogService';
+import './CombatLogViewer.css';
+
+const CombatLogViewer: React.FC = () => {
+  const [events, setEvents] = useState<CombatLogEvent[]>([]);
+
+  useEffect(() => {
+    const handler = (event: CombatLogEvent) => {
+      setEvents(prev => [...prev, event].slice(-20));
+    };
+    combatLogService.on(handler);
+    return () => combatLogService.off(handler);
+  }, []);
+
+  if (!combatLogService.enabled) return null;
+
+  return (
+    <div className="combat-log-viewer">
+      <h4>Actions récentes</h4>
+      <ul>
+        {events.map((e, idx) => (
+          <li key={idx}>{e.message}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CombatLogViewer;

--- a/src/components/ui/GameLayout.tsx
+++ b/src/components/ui/GameLayout.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import GameNav from './GameNav';
 import './GameLayout.css';
 import { bgPattern } from '../../assets/images';
+import CombatLogViewer from '../CombatLogViewer';
 
 interface GameLayoutProps {
   children: ReactNode;
@@ -94,6 +95,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           </div>
         </div>
       </footer>
+      <CombatLogViewer />
     </div>
   );
 };

--- a/src/services/combatLogService.ts
+++ b/src/services/combatLogService.ts
@@ -1,0 +1,46 @@
+import { TagRuleApplicationResult } from '../types/rules';
+import { CardInstance } from '../types/combat';
+
+export interface CombatLogEvent {
+  message: string;
+  result: TagRuleApplicationResult;
+  targetCardId: string;
+  timestamp: number;
+}
+
+type Listener = (event: CombatLogEvent) => void;
+
+class CombatLogService {
+  private listeners: Listener[] = [];
+  public enabled: boolean;
+
+  constructor() {
+    this.enabled =
+      process.env.NODE_ENV !== 'production' &&
+      process.env.REACT_APP_ENABLE_COMBAT_LOGS !== 'false';
+  }
+
+  on(listener: Listener) {
+    this.listeners.push(listener);
+  }
+
+  off(listener: Listener) {
+    this.listeners = this.listeners.filter(l => l !== listener);
+  }
+
+  private emit(event: CombatLogEvent) {
+    if (!this.enabled) return;
+    this.listeners.forEach(l => l(event));
+  }
+
+  logTagRule(result: TagRuleApplicationResult, target: CardInstance) {
+    const message = `Tag '${result.sourceTag}' \u2192 ${result.effectDescription}`;
+    this.emit({ message, result, targetCardId: target.instanceId, timestamp: Date.now() });
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+  }
+}
+
+export const combatLogService = new CombatLogService();

--- a/src/services/combatService.ts
+++ b/src/services/combatService.ts
@@ -19,6 +19,7 @@ import { gameConfigService } from '../utils/dataService';
 import { AttackConditionsService, AttackTargetType } from './attackConditionsService';
 import { Player } from '../types/player';
 import { tagRuleParser } from './tagRuleParserService'; // Import the tagRuleParser
+import { combatLogService } from './combatLogService';
 
 /**
  * @file combatService.ts
@@ -388,12 +389,10 @@ export class CardInstanceImpl implements CardInstance {
         gameState
       );
       
-      // Optionnel: logguer ou traiter les résultats de l'application des règles de tag
+      // Collecter un événement de log pour chaque règle appliquée
       applicationResults.forEach(result => {
         if (result.success) {
-          // console.log(`Rule '${result.effectDescription}' from tag '${result.sourceTag}' applied to ${this.cardDefinition.name}.`);
-        } else if (result.failureReason !== 'Condition non remplie') { // Ne pas logguer toutes les conditions non remplies comme des erreurs
-          // console.warn(`Failed to apply rule '${result.effectDescription}' from tag '${result.sourceTag}': ${result.failureReason}`);
+          combatLogService.logTagRule(result, this);
         }
       });
     });


### PR DESCRIPTION
## Summary
- log tag rule usage via combatLogService
- display recent combat actions with CombatLogViewer component
- show logs in GameLayout and disable when `NODE_ENV=production` or `REACT_APP_ENABLE_COMBAT_LOGS=false`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fb51be10832bb5270651d1f13cdf