### PR TITLE
Ajout de media queries pour petits écrans

### DIFF
--- a/src/components/PlayerBase.css
+++ b/src/components/PlayerBase.css
@@ -150,4 +150,25 @@
     height: 24px;
     font-size: 0.7rem;
   }
-} 
+}
+
+@media (max-width: 480px) {
+  .player-base {
+    width: 150px;
+    padding: 8px;
+  }
+
+  .player-base-header h3 {
+    font-size: 0.9rem;
+  }
+
+  .player-base-health-bar {
+    height: 12px;
+  }
+
+  .player-base-alteration {
+    width: 20px;
+    height: 20px;
+    font-size: 0.6rem;
+  }
+}

--- a/src/components/TagList.css
+++ b/src/components/TagList.css
@@ -143,3 +143,13 @@
     flex-direction: column;
   }
 }
+
+@media (max-width: 480px) {
+  .tag-name {
+    font-size: 14px;
+  }
+
+  .add-tag-button {
+    width: 100%;
+  }
+}

--- a/src/components/ui/GameNav.tsx
+++ b/src/components/ui/GameNav.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 interface GameNavProps {
   user: any;
@@ -11,6 +12,7 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const location = useLocation();
+  const isMobile = useMediaQuery('(max-width:480px)');
 
   // Effet pour détecter le défilement de la page
   useEffect(() => {
@@ -51,6 +53,7 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
           </Link>
         </div>
         
+        {!isMobile && (
         <div className="game-nav-links">
           <Link 
             to="/cards" 
@@ -127,13 +130,17 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             </Link>
           )}
         </div>
-        
-        <button className="mobile-menu-btn" onClick={toggleMobileMenu}>
-          {isMobileMenuOpen ? '✕' : '☰'}
-        </button>
+        )}
+
+        {isMobile && (
+          <button className="mobile-menu-btn" onClick={toggleMobileMenu}>
+            {isMobileMenuOpen ? '✕' : '☰'}
+          </button>
+        )}
       </nav>
-      
+
       {/* Menu mobile */}
+      {isMobile && (
       <div className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''}`}>
         <div className="mobile-menu-links">
           <Link 
@@ -212,6 +219,7 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
           )}
         </div>
       </div>
+      )}
     </>
   );
 };

--- a/src/tests/ui/GameNavResponsive.test.tsx
+++ b/src/tests/ui/GameNavResponsive.test.tsx
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import GameNav from '../../components/ui/GameNav';
+import { MemoryRouter } from 'react-router-dom';
+
+const setupWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+  window.dispatchEvent(new Event('resize'));
+};
+
+beforeAll(() => {
+  window.matchMedia = window.matchMedia || ((query: string) => ({
+    matches: window.innerWidth <= 480,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  } as any));
+});
+
+describe('GameNav responsive behaviour', () => {
+  it('renders mobile menu button on small screens', () => {
+    setupWidth(480);
+    const { container } = render(
+      <MemoryRouter>
+        <GameNav user={{ username: 'test' }} onLogout={() => {}} />
+      </MemoryRouter>
+    );
+    expect(container.querySelector('.mobile-menu-btn')).toBeTruthy();
+    expect(container.querySelector('.game-nav-links')).toBeNull();
+  });
+
+  it('shows nav links on large screens', () => {
+    setupWidth(1024);
+    const { container } = render(
+      <MemoryRouter>
+        <GameNav user={{ username: 'test' }} onLogout={() => {}} />
+      </MemoryRouter>
+    );
+    expect(container.querySelector('.game-nav-links')).toBeTruthy();
+  });
+});

--- a/src/theme/globalStyles.css
+++ b/src/theme/globalStyles.css
@@ -512,6 +512,20 @@ a:hover {
   }
 }
 
+@media (max-width: 480px) {
+  body {
+    font-size: 13px;
+  }
+
+  .main-content {
+    padding: var(--space-sm);
+  }
+
+  h1 {
+    font-size: 1.5rem;
+  }
+}
+
 /* Style pour élément admin */
 .admin-element {
   background: var(--bg-admin);
@@ -631,9 +645,19 @@ a:hover {
   .mobile-menu-btn {
     display: block;
   }
-  
+
   .game-nav-links {
     display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .mobile-menu-btn {
+    font-size: 1.2rem;
+  }
+
+  .mobile-menu-links {
+    padding: var(--space-md);
   }
 }
 


### PR DESCRIPTION
## Summary
- ajuster la réactivité dans `globalStyles.css` et quelques composants
- afficher ou cacher la navigation avec `useMediaQuery`
- tester le comportement de `GameNav` à 480 px

## Testing
- `npm test` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb5a1424832bba714f74ab4dba52