### PR TITLE
Add charisma and rule tests

### DIFF
--- a/src/services/__tests__/combatService.test.ts
+++ b/src/services/__tests__/combatService.test.ts
@@ -58,6 +58,26 @@ const mockSpell: Spell = {
   is_value_percentage: false
 };
 
+// Helper pour créer un joueur de test avec du charisme
+const createTestPlayer = () => ({
+  id: 'player1',
+  name: 'Test Player',
+  activeCard: null,
+  benchCards: [],
+  inventory: [],
+  hand: [],
+  motivation: 0,
+  baseMotivation: 0,
+  motivationModifiers: [],
+  charisme: 10,
+  baseCharisme: 0,
+  maxCharisme: 100,
+  charismeModifiers: [],
+  movementPoints: 0,
+  points: 0,
+  effects: []
+});
+
 describe('CardInstance', () => {
   let cardInstance: CardInstanceImpl;
 
@@ -511,4 +531,28 @@ describe('Résolution simultanée des actions', () => {
     // Restaurer la méthode originale
     (combatManager as any).actionResolutionService.resolveConflictsAutomatically = originalResolveConflicts;
   });
-}); 
+});
+
+describe('Intégration du charisme', () => {
+  test('summonCardForPlayer dépense le charisme requis', () => {
+    const combatManager = new CombatManagerImpl();
+    const player = createTestPlayer();
+
+    const instance = combatManager.summonCardForPlayer(mockCard, player);
+
+    expect(instance).not.toBeNull();
+    expect(player.charisme).toBe(7); // 10 - cost 3
+    expect(combatManager.cardInstances.includes(instance!)).toBe(true);
+  });
+
+  test('handleCardDefeat ajoute le charisme au vainqueur', () => {
+    const combatManager = new CombatManagerImpl();
+    const player = createTestPlayer();
+    const defeated = new CardInstanceImpl({ ...mockCard, rarity: 'cheate' });
+
+    combatManager.handleCardDefeat(defeated, player);
+
+    // cheate rarity gives 40 charisma
+    expect(player.charisme).toBe(50); // 10 + 40
+  });
+});

--- a/src/services/__tests__/tagRuleParserService.test.ts
+++ b/src/services/__tests__/tagRuleParserService.test.ts
@@ -368,5 +368,46 @@ describe('TagRuleParserService', () => {
       expect(targetCard.activeEffects.damageModifier[0].value).toBe(20);
       expect(targetCard.activeEffects.damageModifier[0].isPercentage).toBe(true);
     });
+
+    test('Devrait appliquer un bonus d\'attaque', () => {
+      const rule: TagRule = {
+        name: 'Bonus d\'attaque',
+        description: 'Augmente l\'attaque de 5',
+        effectType: TagRuleEffectType.ATTACK_MODIFIER,
+        value: 5,
+        isPercentage: false,
+        targetType: TagRuleTargetType.SELF
+      };
+
+      parserService.addRuleForTag('NUIT', rule);
+
+      const sourceCard = mockCardInstances[0];
+      const results = parserService.applyTagRules('NUIT', sourceCard, mockCardInstances, mockGameState);
+
+      expect(results[0].success).toBe(true);
+      expect(sourceCard.temporaryStats.attack).toBe(15); // base 10 + 5
+    });
+
+    test('Devrait appliquer un bonus de défense en pourcentage', () => {
+      const rule: TagRule = {
+        name: 'Bonus de défense',
+        description: 'Augmente la défense de 50%',
+        effectType: TagRuleEffectType.DEFENSE_MODIFIER,
+        value: 50,
+        isPercentage: true,
+        targetType: TagRuleTargetType.SELF
+      };
+
+      parserService.addRuleForTag('JOUR', rule);
+
+      const sourceCard = mockCardInstances[1]; // player1_2 avec tag JOUR
+      sourceCard.temporaryStats.defense = 4;
+      (sourceCard.cardDefinition.properties as any).defense = 4;
+
+      const results = parserService.applyTagRules('JOUR', sourceCard, mockCardInstances, mockGameState);
+
+      expect(results[0].success).toBe(true);
+      expect(sourceCard.temporaryStats.defense).toBe(6); // 4 + 50% of base (4) => +2
+    });
   });
-}); 
+});

--- a/src/services/combatService.ts
+++ b/src/services/combatService.ts
@@ -18,6 +18,12 @@ import { ActionResolutionService, ActionType } from './actionResolutionService';
 import { gameConfigService } from '../utils/dataService';
 import { AttackConditionsService, AttackTargetType } from './attackConditionsService';
 import { Player } from '../types/player';
+import {
+  addCharisme,
+  spendCharisme,
+  calculateCharismeFromDefeat,
+  Player as CharismePlayer,
+} from '../utils/charismeService';
 import { tagRuleParser } from './tagRuleParserService'; // Import the tagRuleParser
 
 /**
@@ -1264,6 +1270,31 @@ export class CombatManagerImpl implements CombatManager {
    */
   public convertCardToInstance(card: Card, tags?: Tag[], spells?: Spell[]): CardInstance {
     return this.cardConversionService.convertCardToInstance(card, tags, spells);
+  }
+
+  /**
+   * Invoque une carte pour un joueur en dépensant son charisme.
+   * Retourne l'instance invoquée ou null si le joueur n'a pas assez de ressources.
+   */
+  public summonCardForPlayer(card: Card, player: CharismePlayer): CardInstance | null {
+    const cost = card.summon_cost || 0;
+    const updated = spendCharisme(player, cost);
+    if (!updated) {
+      return null;
+    }
+    Object.assign(player, updated);
+    const instance = this.initializeCardInstance(card);
+    this.cardInstances.push(instance);
+    return instance;
+  }
+
+  /**
+   * Gère le gain de charisme lorsqu'une carte est vaincue.
+   */
+  public handleCardDefeat(defeated: CardInstance, winner: CharismePlayer): void {
+    const gain = calculateCharismeFromDefeat(defeated.cardDefinition as any);
+    const updated = addCharisme(winner, gain);
+    Object.assign(winner, updated);
   }
 
   /**


### PR DESCRIPTION
## Summary
- extend `CombatManagerImpl` with charisma spend/gain helpers
- test charisma spending and gain via CombatManager
- test new attack and defense modifier rule types

## Testing
- `npm run test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6841fb363f70832b83ddd1396df4ecc3