### PR TITLE
Add exec_sql helper and fix deck trigger order

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ For continuous integration environments, use:
 npm run test:ci
 ```
 
+## Database Migrations
+
+The database schema is managed via SQL migrations. A helper RPC
+`exec_sql(sql text)` is defined in `schema.sql` and executed with definer
+privileges. Migrations rely on this function to run dynamic statements, so
+ensure it is present before applying new migrations.
+
 ## License
 
 This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/schema.sql
+++ b/schema.sql
@@ -72,12 +72,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+
+-- Utility RPC used by migrations
+CREATE OR REPLACE FUNCTION public.exec_sql(sql text)
+RETURNS void AS $$
+BEGIN
+  EXECUTE sql;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
 -- Suppression des triggers existants s'ils existent
 DROP TRIGGER IF EXISTS set_updated_at ON cards;
 DROP TRIGGER IF EXISTS set_updated_at ON alterations;
 DROP TRIGGER IF EXISTS set_updated_at ON spells;
 DROP TRIGGER IF EXISTS set_updated_at ON tags;
-DROP TRIGGER IF EXISTS update_decks_updated_at ON decks;
 DROP TRIGGER IF EXISTS check_spell_references_trigger ON card_spells;
 DROP TRIGGER IF EXISTS check_tag_references_trigger ON card_tags;
 
@@ -153,6 +161,7 @@ CREATE TABLE IF NOT EXISTS decks (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+DROP TRIGGER IF EXISTS update_decks_updated_at ON decks;
 
 -- Table de composition des decks
 CREATE TABLE IF NOT EXISTS deck_cards (


### PR DESCRIPTION
## Summary
- create `exec_sql` RPC in `schema.sql`
- move the deck trigger drop statement after the `decks` table
- document the RPC in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684214880a50832b81f1b18b798cb54b