### PR TITLE
Add inventory sell feature

### DIFF
--- a/src/services/__tests__/playerInventoryService.test.ts
+++ b/src/services/__tests__/playerInventoryService.test.ts
@@ -1,0 +1,61 @@
+import { PlayerInventoryService } from '../playerInventoryService';
+import { Player, Card, Rarity } from '../../types/index';
+import { addCharismeModifier } from '../../utils/charismeService';
+
+const createTestPlayer = (): Player => ({
+  id: 'player1',
+  name: 'Test Player',
+  activeCard: null,
+  benchCards: [],
+  inventory: [],
+  hand: [],
+  motivation: 0,
+  baseMotivation: 0,
+  motivationModifiers: [],
+  charisme: 0,
+  baseCharisme: 0,
+  maxCharisme: 100,
+  charismeModifiers: [],
+  movementPoints: 0,
+  points: 0,
+  effects: []
+});
+
+const createTestItem = (id: number, rarity: Rarity): Card => ({
+  id,
+  name: 'Item',
+  description: 'Test item',
+  type: 'objet',
+  rarity,
+  properties: {},
+  summon_cost: 0,
+  image: null,
+  passive_effect: null,
+  is_wip: false,
+  is_crap: false
+});
+
+describe('PlayerInventoryService.sellItem', () => {
+  it('removes item from inventory and adds charisme', () => {
+    const player = createTestPlayer();
+    const item = createTestItem(1, 'banger');
+    player.inventory = [item];
+
+    const result = PlayerInventoryService.sellItem(player, 1);
+
+    expect(result.inventory).toHaveLength(0);
+    expect(result.charisme).toBe(20);
+  });
+
+  it('applies charisme modifiers when selling', () => {
+    let player = createTestPlayer();
+    const item = createTestItem(1, 'banger');
+    player.inventory = [item];
+    player = addCharismeModifier(player, 50, true, 'bonus', 'generation');
+
+    const result = PlayerInventoryService.sellItem(player, 1);
+
+    expect(result.inventory).toHaveLength(0);
+    expect(result.charisme).toBe(30); // 20 base +50%
+  });
+});

--- a/src/services/playerInventoryService.ts
+++ b/src/services/playerInventoryService.ts
@@ -1,0 +1,33 @@
+
+import type { Player, Card } from '../types/index';
+import { Rarity, CHARISME_GAIN_BY_RARITY, addCharisme } from '../utils/charismeService';
+
+/**
+ * Service de gestion de l'inventaire des joueurs.
+ */
+export class PlayerInventoryService {
+  /**
+   * Vend un objet de l'inventaire du joueur et lui ajoute du charisme.
+   * Le montant de charisme obtenu dépend de la rareté de l'objet vendu
+   * et est soumis aux modificateurs via {@link addCharisme}.
+   *
+   * @param player Joueur possédant l'objet
+   * @param itemId Identifiant de l'objet à vendre
+   * @returns Le joueur mis à jour
+   */
+  public static sellItem(player: Player, itemId: number): Player {
+    const item = player.inventory.find(c => c.id === itemId);
+    if (!item) {
+      return player;
+    }
+
+    const updatedInventory = player.inventory.filter(c => c.id !== itemId);
+    const rarity = item.rarity as Rarity;
+    const baseGain = CHARISME_GAIN_BY_RARITY[rarity] ?? 0;
+
+    const playerWithoutItem: Player = { ...player, inventory: updatedInventory };
+    return addCharisme(playerWithoutItem, baseGain);
+  }
+}
+
+export const playerInventoryService = new PlayerInventoryService();


### PR DESCRIPTION
## Summary
- implement `PlayerInventoryService.sellItem` to sell a card for charisma
- add unit tests for selling with and without modifiers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421cfd5a38832b92655251840b57c5