### PR TITLE
Add charisme tests and fix combat manager usage

### DIFF
--- a/src/services/combatService.ts
+++ b/src/services/combatService.ts
@@ -23,6 +23,7 @@ import {
   spendCharisme,
   calculateCharismeFromDefeat,
   Player as CharismePlayer,
+  Card as CharismeCard,
 } from '../utils/charismeService';
 import { tagRuleParser } from './tagRuleParserService'; // Import the tagRuleParser
 import { combatLogService } from './combatLogService';
@@ -1303,7 +1304,6 @@ export class CombatManagerImpl implements CombatManager {
     }
     Object.assign(player, updated);
     const instance = this.initializeCardInstance(card);
-    this.cardInstances.push(instance);
     return instance;
   }
 
@@ -1311,7 +1311,7 @@ export class CombatManagerImpl implements CombatManager {
    * Gère le gain de charisme lorsqu'une carte est vaincue.
    */
   public handleCardDefeat(defeated: CardInstance, winner: CharismePlayer): void {
-    const gain = calculateCharismeFromDefeat(defeated.cardDefinition as any);
+    const gain = calculateCharismeFromDefeat(defeated.cardDefinition as CharismeCard);
     const updated = addCharisme(winner, gain);
     Object.assign(winner, updated);
   }

--- a/src/tests/services/combatCharisme.test.ts
+++ b/src/tests/services/combatCharisme.test.ts
@@ -1,0 +1,80 @@
+import { v4 as uuidv4 } from 'uuid';
+import { CombatManagerImpl, CardInstanceImpl } from '../../services/combatService';
+import {
+  Player as CharismePlayer,
+  initializePlayerCharisme,
+  CHARISME_GAIN_BY_RARITY,
+} from '../../utils/charismeService';
+import { Card } from '../../types/index';
+
+const createTestPlayer = (): CharismePlayer => {
+  const base: any = {
+    id: uuidv4(),
+    name: 'Test Player',
+    activeCard: null,
+    benchCards: [],
+    inventory: [],
+    hand: [],
+    motivation: 10,
+    baseMotivation: 10,
+    motivationModifiers: [],
+    movementPoints: 0,
+    points: 0,
+    effects: [],
+  };
+  return initializePlayerCharisme(base);
+};
+
+const testCard: Card = {
+  id: 1,
+  name: 'Test Card',
+  description: null,
+  type: 'personnage',
+  rarity: 'gros_bodycount',
+  properties: { health: 5 },
+  summon_cost: 5,
+  image: null,
+  passive_effect: null,
+  is_wip: false,
+  is_crap: false,
+};
+
+describe('CombatService - Charisme', () => {
+  let combat: CombatManagerImpl;
+
+  beforeEach(() => {
+    combat = new CombatManagerImpl();
+  });
+
+  test('summonCardForPlayer dépense le charisme du joueur', () => {
+    const player = createTestPlayer();
+    player.charisme = 10;
+
+    const instance = combat.summonCardForPlayer(testCard, player);
+
+    expect(instance).not.toBeNull();
+    expect(player.charisme).toBe(5);
+    expect(combat.cardInstances.length).toBe(1);
+  });
+
+  test('summonCardForPlayer échoue si charisme insuffisant', () => {
+    const player = createTestPlayer();
+    player.charisme = 3;
+
+    const instance = combat.summonCardForPlayer(testCard, player);
+
+    expect(instance).toBeNull();
+    expect(player.charisme).toBe(3);
+    expect(combat.cardInstances.length).toBe(0);
+  });
+
+  test('handleCardDefeat ajoute le charisme au vainqueur', () => {
+    const player = createTestPlayer();
+    player.charisme = 0;
+    const defeated = new CardInstanceImpl(testCard);
+
+    combat.handleCardDefeat(defeated, player);
+
+    expect(player.charisme).toBe(CHARISME_GAIN_BY_RARITY.gros_bodycount);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure combat operations use charisme helpers with proper typing
- prevent duplicate instance registration when summoning
- verify charisme spending and gain in new combat service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421ceef55c832b89cf1a88564fc18b