### PR TITLE
Add eventDuration property to Card

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -14,6 +14,7 @@
   - `passive_effect`: Effet passif de la carte
   - `properties`: Propriétés spécifiques (points de vie, etc.)
   - `summon_cost`: Coût d'invocation
+  - `eventDuration`: Pour les cartes `evenement`, indique si l'effet est `instantanee`, `temporaire` ou `permanente`
   - `is_wip`: Indique si la carte est en cours de développement
   - `is_crap`: Indique si la carte est à retravailler
 

--- a/src/components/CardForm.tsx
+++ b/src/components/CardForm.tsx
@@ -28,6 +28,8 @@ interface CardFormProps {
 
 type CardInputEvent = React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
 
+const EVENT_DURATIONS = ['instantanee', 'temporaire', 'permanente'] as const;
+
 const defaultCard: Card = {
   id: 0,
   name: '',
@@ -206,9 +208,19 @@ const CardForm: React.FC<CardFormProps> = ({
     }
 
     if (name === 'type') {
+      const newType = value as Card['type'];
       setLocalCard((prev: Card): Card => ({
         ...prev,
-        type: value as Card['type']
+        type: newType,
+        eventDuration: newType === 'evenement' ? (prev.eventDuration || 'instantanee') : undefined
+      }));
+      return;
+    }
+
+    if (name === 'eventDuration') {
+      setLocalCard((prev: Card): Card => ({
+        ...prev,
+        eventDuration: value as Card['eventDuration']
       }));
       return;
     }
@@ -460,6 +472,24 @@ const CardForm: React.FC<CardFormProps> = ({
                     </select>
                   </div>
                 </div>
+
+                {localCard.type === 'evenement' && (
+                  <div className="form-group">
+                    <label htmlFor="eventDuration" className="required-field">Durée de l'événement</label>
+                    <select
+                      id="eventDuration"
+                      name="eventDuration"
+                      value={localCard.eventDuration || 'instantanee'}
+                      onChange={handleChange}
+                      required
+                      className="form-input"
+                    >
+                      {EVENT_DURATIONS.map(d => (
+                        <option key={d} value={d}>{d.charAt(0).toUpperCase() + d.slice(1)}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
 
                 <div className="form-group">
                   <label htmlFor="description">Description</label>

--- a/src/tests/utils/validation.test.ts
+++ b/src/tests/utils/validation.test.ts
@@ -194,6 +194,65 @@ describe('validateCardSync', () => {
       expect(errors.length).toBeGreaterThan(0);
       expect(errors).toContain('Le coût d\'invocation doit être positif pour les cartes action');
     });
+
+    it("devrait exiger eventDuration pour un événement", () => {
+      const invalidEvent: Card = {
+        id: 1,
+        name: 'Event Test',
+        type: 'evenement',
+        rarity: 'interessant',
+        description: '',
+        image: 'event.jpg',
+        passive_effect: '',
+        properties: {},
+        is_wip: false,
+        is_crap: false,
+        summon_cost: 2
+      };
+
+      const errors = validateCardSync(invalidEvent);
+      expect(errors).toContain("La durée d'\u00E9vénement est requise pour les cartes Evenement");
+    });
+
+    it("devrait détecter une valeur eventDuration invalide", () => {
+      const invalidEvent: Card = {
+        id: 1,
+        name: 'Event Test',
+        type: 'evenement',
+        rarity: 'interessant',
+        description: '',
+        image: 'event.jpg',
+        passive_effect: '',
+        properties: {},
+        is_wip: false,
+        is_crap: false,
+        summon_cost: 2,
+        eventDuration: 'inconnue' as any
+      };
+
+      const errors = validateCardSync(invalidEvent);
+      expect(errors).toContain("La durée d'\u00E9vénement doit être 'instantanee', 'temporaire' ou 'permanente'");
+    });
+
+    it("devrait valider un événement avec eventDuration", () => {
+      const validEvent: Card = {
+        id: 1,
+        name: 'Event Test',
+        type: 'evenement',
+        rarity: 'interessant',
+        description: '',
+        image: 'event.jpg',
+        passive_effect: '',
+        properties: {},
+        is_wip: false,
+        is_crap: false,
+        summon_cost: 2,
+        eventDuration: 'temporaire'
+      };
+
+      const errors = validateCardSync(validEvent);
+      expect(errors.length).toBe(0);
+    });
   });
 
   // Tests pour la validation de coût par rareté
@@ -218,7 +277,8 @@ describe('validateCardSync', () => {
           properties: {},
           is_wip: false,
           is_crap: false,
-          summon_cost: cost
+          summon_cost: cost,
+          eventDuration: 'instantanee'
         };
         
         const errors = validateCardSync(card);
@@ -245,7 +305,8 @@ describe('validateCardSync', () => {
           properties: {},
           is_wip: false,
           is_crap: false,
-          summon_cost: cost
+          summon_cost: cost,
+          eventDuration: 'instantanee'
         };
         
         const errors = validateCardSync(card);

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Card {
   description: string;
   image: string;
   passive_effect: string;
+  eventDuration?: 'instantanee' | 'temporaire' | 'permanente';
   properties: {
     health?: number;
     [key: string]: any;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -113,6 +113,13 @@ export interface Card {
   description: string | null;
   type: 'personnage' | 'objet' | 'evenement' | 'lieu' | 'action';
   rarity: Rarity | string;
+  /**
+   * Pour les cartes "evenement", indique la durée de l’effet
+   * - "instantanee" : effet appliqué une seule fois
+   * - "temporaire" : effet qui dure quelques tours
+   * - "permanente" : effet qui reste jusqu'à la fin de la partie
+   */
+  eventDuration?: 'instantanee' | 'temporaire' | 'permanente';
   properties: {
     health?: number;
     [key: string]: any;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -46,10 +46,18 @@ export const validateCard = async (card: Card): Promise<string[]> => {
       }
       break;
     case 'action':
-    case 'evenement':
-      // Validation pour les cartes action et événement
       if (card.summon_cost <= 0) {
-        errors.push(`Le coût d'invocation doit être positif pour les cartes ${card.type}`);
+        errors.push("Le coût d'invocation doit être positif pour les cartes action");
+      }
+      break;
+    case 'evenement':
+      if (!card.eventDuration) {
+        errors.push("La durée d'\u00E9vénement est requise pour les cartes Evenement");
+      } else if (!['instantanee', 'temporaire', 'permanente'].includes(card.eventDuration)) {
+        errors.push("La durée d'\u00E9vénement doit être 'instantanee', 'temporaire' ou 'permanente'");
+      }
+      if (card.summon_cost <= 0) {
+        errors.push("Le coût d'invocation doit être positif pour les cartes evenement");
       }
       break;
     default:
@@ -159,10 +167,18 @@ export const validateCardSync = (card: Card): string[] => {
       }
       break;
     case 'action':
-    case 'evenement':
-      // Validation pour les cartes action et événement
       if (card.summon_cost <= 0) {
-        errors.push(`Le coût d'invocation doit être positif pour les cartes ${card.type}`);
+        errors.push("Le coût d'invocation doit être positif pour les cartes action");
+      }
+      break;
+    case 'evenement':
+      if (!card.eventDuration) {
+        errors.push("La durée d'\u00E9vénement est requise pour les cartes Evenement");
+      } else if (!['instantanee', 'temporaire', 'permanente'].includes(card.eventDuration)) {
+        errors.push("La durée d'\u00E9vénement doit être 'instantanee', 'temporaire' ou 'permanente'");
+      }
+      if (card.summon_cost <= 0) {
+        errors.push("Le coût d'invocation doit être positif pour les cartes evenement");
       }
       break;
     default:


### PR DESCRIPTION
## Summary
- extend Card interface with new `eventDuration` field
- support event duration selection in CardForm
- validate `eventDuration` in card validators
- update docs and tests for the new property

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421d021848832baaabd40ab65bee9f