### PR TITLE
Add manual targeting failure test

### DIFF
--- a/src/services/__tests__/targetingService.test.ts
+++ b/src/services/__tests__/targetingService.test.ts
@@ -265,4 +265,16 @@ describe('TargetingService', () => {
     expect(result.error).toBeDefined();
     expect(result.targets).toHaveLength(0);
   });
-}); 
+
+  test('devrait échouer si le ciblage manuel n\'est pas configuré', async () => {
+    const result = await targetingService.getTargets(
+      sourceCard,
+      'manual',
+      allCards
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.targets).toHaveLength(0);
+    expect(result.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `TargetingService` returns an error when the manual callback isn't set

## Testing
- `npm test -- src/services/__tests__/targetingService.test.ts --runTestsByPath`
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_68421cf0dde0832bb183203c1657a1a1