### PR TITLE
Add deck simulation panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { supabase } from './utils/supabaseClient';
 // Import de nos nouveaux composants UI
 import { GameLayout, GameCardGrid, AdminPanel, Notification } from './components/ui';
 import ManualTargetSelector from './components/ManualTargetSelector';
+import SimulationPanel from './components/SimulationPanel';
 import { TargetingService, TargetingResult } from './services/targetingService';
 import { CardInstance } from './types/combat';
 
@@ -399,6 +400,9 @@ const AppContent: React.FC = () => {
                 <button className="btn btn-secondary btn-lg" onClick={() => navigate('/gameboard')}>
                   Tester le jeu
                 </button>
+                <button className="btn btn-primary btn-lg" onClick={() => navigate('/simulation')}>
+                  Simulations
+                </button>
               </div>
             </div>
             
@@ -550,7 +554,12 @@ const AppContent: React.FC = () => {
         <Route path="/gameboard" element={
           <GameBoardTest />
         } />
-        
+
+        {/* Panneau de simulation */}
+        <Route path="/simulation" element={
+          <SimulationPanel user={user} />
+        } />
+
         {/* Redirection par défaut */}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/components/SimulationPanel.tsx
+++ b/src/components/SimulationPanel.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { userService } from '../utils/userService';
+import { simulationResultsService } from '../utils/dataService';
+import { simulateGame } from '../simulation/gameSimulator';
+import type { Deck } from '../types/userTypes';
+
+interface SimulationPanelProps {
+  user: { id: string } | null;
+}
+
+const SimulationPanel: React.FC<SimulationPanelProps> = ({ user }) => {
+  const [decks, setDecks] = useState<Deck[]>([]);
+  const [deckA, setDeckA] = useState('');
+  const [deckB, setDeckB] = useState('');
+  const [history, setHistory] = useState<any[]>([]);
+  const [runs, setRuns] = useState(1);
+  const [performance, setPerformance] = useState<{
+    winRate: number;
+    averageTurns: number;
+    totalGames: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (user) {
+        const userDecks = await userService.getDecks(user.id);
+        setDecks(userDecks || []);
+      }
+      fetchHistory();
+    };
+    load();
+  }, [user]);
+
+  const fetchHistory = async (deckId?: string) => {
+    const results = deckId
+      ? await simulationResultsService.getByDeck(deckId)
+      : await simulationResultsService.getAll();
+    setHistory(results);
+  };
+
+  const runSimulation = async () => {
+    if (!deckA || !deckB) return;
+    for (let i = 0; i < runs; i++) {
+      await simulateGame({ deckId: deckA, opponentDeckId: deckB, simulationType: 'performance' });
+    }
+    await fetchHistory(deckA);
+    const perf = await simulationResultsService.getDeckPerformance(deckA);
+    setPerformance(perf);
+  };
+
+  return (
+    <div className="simulation-panel">
+      <h2>Simulations</h2>
+      <div className="sim-form">
+        <label>
+          Deck A
+          <select value={deckA} onChange={e => setDeckA(e.target.value)}>
+            <option value="">Choisir un deck</option>
+            {decks.map(d => (
+              <option key={d.id} value={d.id}>{d.name}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Deck B
+          <select value={deckB} onChange={e => setDeckB(e.target.value)}>
+            <option value="">Choisir un deck</option>
+            {decks.map(d => (
+              <option key={d.id} value={d.id}>{d.name}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Nombre de simulations
+          <input type="number" min="1" value={runs} onChange={e => setRuns(parseInt(e.target.value, 10))} />
+        </label>
+        <button className="btn btn-primary" onClick={runSimulation}>Lancer</button>
+      </div>
+
+      {performance && (
+        <div className="performance-stats">
+          <h3>Statistiques du deck {deckA}</h3>
+          <p>Taux de victoire: {(performance.winRate * 100).toFixed(1)}%</p>
+          <p>Nombre moyen de tours: {performance.averageTurns.toFixed(2)}</p>
+          <p>Parties totales: {performance.totalGames}</p>
+        </div>
+      )}
+
+      <h3>Historique</h3>
+      <ul>
+        {history.map(res => (
+          <li key={res.id}>
+            {res.deck_id} vs {res.opponent_deck_id} : {res.result.won ? 'victoire' : 'défaite'} en {res.result.turns} tours
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SimulationPanel;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as PlayerBase } from './PlayerBase';
 export { default as ConflictResolutionManager } from './ConflictResolutionManager';
 export { default as ConflictResolutionDemo } from './ConflictResolutionDemo';
 export { default as ManualTargetSelector } from './ManualTargetSelector';
+export { default as SimulationPanel } from './SimulationPanel';

--- a/src/components/ui/GameNav.tsx
+++ b/src/components/ui/GameNav.tsx
@@ -87,12 +87,20 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             Altérations
           </Link>
           
-          <Link 
-            to="/gameboard" 
+          <Link
+            to="/gameboard"
             onClick={closeMobileMenu}
             className={`nav-link ${isActive('/gameboard') ? 'active' : ''}`}
           >
             Plateau
+          </Link>
+
+          <Link
+            to="/simulation"
+            onClick={closeMobileMenu}
+            className={`nav-link ${isActive('/simulation') ? 'active' : ''}`}
+          >
+            Simulations
           </Link>
           
           {isAdmin && (
@@ -175,12 +183,20 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             Altérations
           </Link>
           
-          <Link 
-            to="/gameboard" 
+          <Link
+            to="/gameboard"
             onClick={closeMobileMenu}
             className={`mobile-nav-link ${isActive('/gameboard') ? 'active' : ''}`}
           >
             Plateau
+          </Link>
+
+          <Link
+            to="/simulation"
+            onClick={closeMobileMenu}
+            className={`mobile-nav-link ${isActive('/simulation') ? 'active' : ''}`}
+          >
+            Simulations
           </Link>
           
           {isAdmin && (


### PR DESCRIPTION
## Summary
- provide new `SimulationPanel` component to run match simulations
- link to simulation panel via navigation and home quick actions
- add `/simulation` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843123bed58832b94d56161210279fd