### PR TITLE
Add Achievements page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import './App.css';
 import AlterationManager from './components/AlterationManager';
 import Objectives from './components/Objectives';
 import TodoProgress from './components/TodoProgress';
+import Achievements from './components/Achievements';
 import { supabase } from './utils/supabaseClient';
 
 // Import de nos nouveaux composants UI
@@ -529,7 +530,12 @@ const AppContent: React.FC = () => {
         <Route path="/alterations" element={
           <AlterationManager onChange={handleAlterationChange} />
         } />
-        
+
+        {/* Réalisations */}
+        <Route path="/achievements" element={
+          <Achievements user={user as User} />
+        } />
+
         {/* Page d'aide */}
         <Route path="/help" element={
           <Help />

--- a/src/components/Achievements.css
+++ b/src/components/Achievements.css
@@ -1,0 +1,47 @@
+.achievements-container {
+  padding: var(--space-lg);
+  color: var(--text-primary);
+}
+
+.achievements-section {
+  margin-bottom: var(--space-lg);
+}
+
+.achievements-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-md);
+}
+
+.achievement-card {
+  background: rgba(22, 22, 38, 0.8);
+  border: 1px solid var(--border-medium);
+  border-radius: 8px;
+  padding: var(--space-md);
+  text-align: center;
+}
+
+.achievement-card.unlocked {
+  border-color: var(--color-primary);
+}
+
+.achievement-card.locked {
+  opacity: 0.6;
+}
+
+.achievement-icon {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  margin-bottom: var(--space-sm);
+}
+
+.achievement-info h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.achievement-info p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}

--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { userService } from '../utils/userService';
+import { supabase } from '../utils/supabaseClient';
+import type { Achievement } from '../types/userTypes';
+import './Achievements.css';
+
+interface AchievementsProps {
+  user: { id: string };
+}
+
+const Achievements: React.FC<AchievementsProps> = ({ user }) => {
+  const [unlocked, setUnlocked] = useState<Achievement[]>([]);
+  const [locked, setLocked] = useState<Achievement[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const userAchievements = await userService.getAchievements(user.id);
+        const unlockedAchievements = (userAchievements || []).map((ua: any) => ua.achievements as Achievement);
+        setUnlocked(unlockedAchievements);
+
+        const { data: allAchievements, error } = await supabase
+          .from('achievements')
+          .select('*');
+        if (error) throw error;
+        const lockedAchievements = (allAchievements || []).filter((a: Achievement) =>
+          !unlockedAchievements.some(u => u.id === a.id)
+        );
+        setLocked(lockedAchievements);
+      } catch (err) {
+        console.error('Erreur lors du chargement des réalisations:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [user.id]);
+
+  if (loading) {
+    return <div className="achievements-container">Chargement...</div>;
+  }
+
+  return (
+    <div className="achievements-container">
+      <h1>Réalisations</h1>
+
+      <section className="achievements-section">
+        <h2>Débloquées</h2>
+        <div className="achievements-grid">
+          {unlocked.map(ach => (
+            <div key={ach.id} className="achievement-card unlocked">
+              {ach.icon_url && (
+                <img src={ach.icon_url} alt={ach.name} className="achievement-icon" />
+              )}
+              <div className="achievement-info">
+                <h3>{ach.name}</h3>
+                <p>{ach.description}</p>
+              </div>
+            </div>
+          ))}
+          {unlocked.length === 0 && <p>Aucune réalisation débloquée.</p>}
+        </div>
+      </section>
+
+      <section className="achievements-section">
+        <h2>À débloquer</h2>
+        <div className="achievements-grid">
+          {locked.map(ach => (
+            <div key={ach.id} className="achievement-card locked">
+              {ach.icon_url && (
+                <img src={ach.icon_url} alt={ach.name} className="achievement-icon" />
+              )}
+              <div className="achievement-info">
+                <h3>{ach.name}</h3>
+                <p>{ach.description}</p>
+              </div>
+            </div>
+          ))}
+          {locked.length === 0 && <p>Toutes les réalisations sont débloquées !</p>}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Achievements;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as PlayerBase } from './PlayerBase';
 export { default as ConflictResolutionManager } from './ConflictResolutionManager';
 export { default as ConflictResolutionDemo } from './ConflictResolutionDemo';
 export { default as ManualTargetSelector } from './ManualTargetSelector';
+export { default as Achievements } from './Achievements';

--- a/src/components/ui/GameNav.tsx
+++ b/src/components/ui/GameNav.tsx
@@ -87,12 +87,20 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             Altérations
           </Link>
           
-          <Link 
-            to="/gameboard" 
+          <Link
+            to="/gameboard"
             onClick={closeMobileMenu}
             className={`nav-link ${isActive('/gameboard') ? 'active' : ''}`}
           >
             Plateau
+          </Link>
+
+          <Link
+            to="/achievements"
+            onClick={closeMobileMenu}
+            className={`nav-link ${isActive('/achievements') ? 'active' : ''}`}
+          >
+            Succès
           </Link>
           
           {isAdmin && (
@@ -175,12 +183,20 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             Altérations
           </Link>
           
-          <Link 
-            to="/gameboard" 
+          <Link
+            to="/gameboard"
             onClick={closeMobileMenu}
             className={`mobile-nav-link ${isActive('/gameboard') ? 'active' : ''}`}
           >
             Plateau
+          </Link>
+
+          <Link
+            to="/achievements"
+            onClick={closeMobileMenu}
+            className={`mobile-nav-link ${isActive('/achievements') ? 'active' : ''}`}
+          >
+            Succès
           </Link>
           
           {isAdmin && (


### PR DESCRIPTION
## Summary
- create Achievements page to fetch and display unlocked and locked achievements
- export new component
- link Achievements from GameNav (desktop & mobile)
- route `/achievements` in App
- simple styling for achievement cards

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431235e74c832bbf7643cace134720