### PR TITLE
Add conflict settings admin page

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -249,7 +249,9 @@ INSERT INTO public.game_config (key, value, description) VALUES
     ('max_personnages', '{"value": 5}', 'Nombre maximum de personnages sur le terrain'),
     ('emplacements_objet', '{"value": 3}', 'Nombre d''emplacements d''objets par personnage'),
     ('budget_motivation_initial', '{"value": 10}', 'Budget de motivation initial par tour'),
-    ('pv_base_initial', '{"value": 100}', 'Points de vie initiaux de la base')
+    ('pv_base_initial', '{"value": 100}', 'Points de vie initiaux de la base'),
+    ('conflict_strategy', '{"value": "fifo"}', 'Stratégie de résolution des conflits'),
+    ('conflict_random_chance', '{"value": 0}', 'Probabilité de résolution aléatoire des conflits')
 ON CONFLICT (key) DO NOTHING;
 
 -- Table des résultats de simulation

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { supabase } from './utils/supabaseClient';
 import { GameLayout, GameCardGrid, AdminPanel, Notification } from './components/ui';
 import ManualTargetSelector from './components/ManualTargetSelector';
 import SimulationPanel from './components/SimulationPanel';
+import ConflictSettingsPage from './components/ConflictSettingsPage';
 import { TargetingService, TargetingResult } from './services/targetingService';
 import { CardInstance } from './types/combat';
 
@@ -562,6 +563,17 @@ const AppContent: React.FC = () => {
           user?.is_admin ? (
             <AdminPanel title="Debug" icon="🛠">
               <DebugPanel />
+            </AdminPanel>
+          ) : (
+            <Navigate to="/" replace />
+          )
+        } />
+
+        {/* Gestion des conflits (admin uniquement) */}
+        <Route path="/conflicts" element={
+          user?.is_admin ? (
+            <AdminPanel title="Résolution des conflits" icon="⚔️">
+              <ConflictSettingsPage />
             </AdminPanel>
           ) : (
             <Navigate to="/" replace />

--- a/src/components/ConflictSettingsPage.tsx
+++ b/src/components/ConflictSettingsPage.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { ConflictResolutionManager } from './index';
+import { ConflictResolutionStrategy } from '../services/actionResolutionService';
+import { gameConfigService } from '../utils/dataService';
+
+const DEFAULT_STRATEGY = ConflictResolutionStrategy.FIFO;
+const DEFAULT_RANDOM = 0;
+
+const ConflictSettingsPage: React.FC = () => {
+  const [strategy, setStrategy] = useState<ConflictResolutionStrategy>(DEFAULT_STRATEGY);
+  const [randomChance, setRandomChance] = useState<number>(DEFAULT_RANDOM);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const s = await gameConfigService.getValue<string>('conflict_strategy');
+        const r = await gameConfigService.getValue<number>('conflict_random_chance');
+        if (s) {
+          setStrategy(s as ConflictResolutionStrategy);
+        }
+        if (r !== null && r !== undefined) {
+          setRandomChance(r);
+        }
+      } catch (err) {
+        console.error('Erreur chargement config conflit:', err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleStrategyChange = async (newStrategy: ConflictResolutionStrategy) => {
+    setStrategy(newStrategy);
+    try {
+      await gameConfigService.update('conflict_strategy', { value: newStrategy });
+    } catch (err) {
+      console.error('Erreur maj stratégie:', err);
+    }
+  };
+
+  const handleRandomChange = async (chance: number) => {
+    setRandomChance(chance);
+    try {
+      await gameConfigService.update('conflict_random_chance', { value: chance });
+    } catch (err) {
+      console.error('Erreur maj probabilité:', err);
+    }
+  };
+
+  return (
+    <ConflictResolutionManager
+      currentStrategy={strategy}
+      randomChance={randomChance}
+      onStrategyChange={handleStrategyChange}
+      onRandomChanceChange={handleRandomChange}
+      conflicts={[]}
+      resolutions={[]}
+    />
+  );
+};
+
+export default ConflictSettingsPage;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,3 +14,4 @@ export { default as ManualTargetSelector } from './ManualTargetSelector';
 export { default as Achievements } from './Achievements';
 export { default as DebugPanel } from './DebugPanel';
 export { default as SimulationPanel } from './SimulationPanel';
+export { default as ConflictSettingsPage } from './ConflictSettingsPage';

--- a/src/components/ui/GameNav.tsx
+++ b/src/components/ui/GameNav.tsx
@@ -112,13 +112,22 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
           </Link>
           
           {isAdmin && (
-            <Link 
-              to="/users" 
-              onClick={closeMobileMenu}
-              className={`nav-link admin-link ${isActive('/users') ? 'active' : ''}`}
-            >
-              Utilisateurs
-            </Link>
+            <>
+              <Link
+                to="/users"
+                onClick={closeMobileMenu}
+                className={`nav-link admin-link ${isActive('/users') ? 'active' : ''}`}
+              >
+                Utilisateurs
+              </Link>
+              <Link
+                to="/conflicts"
+                onClick={closeMobileMenu}
+                className={`nav-link admin-link ${isActive('/conflicts') ? 'active' : ''}`}
+              >
+                Conflits
+              </Link>
+            </>
           )}
           
           <Link 
@@ -215,13 +224,22 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
           </Link>
           
           {isAdmin && (
-            <Link 
-              to="/users" 
-              onClick={closeMobileMenu}
-              className={`mobile-nav-link admin-link ${isActive('/users') ? 'active' : ''}`}
-            >
-              Utilisateurs
-            </Link>
+            <>
+              <Link
+                to="/users"
+                onClick={closeMobileMenu}
+                className={`mobile-nav-link admin-link ${isActive('/users') ? 'active' : ''}`}
+              >
+                Utilisateurs
+              </Link>
+              <Link
+                to="/conflicts"
+                onClick={closeMobileMenu}
+                className={`mobile-nav-link admin-link ${isActive('/conflicts') ? 'active' : ''}`}
+              >
+                Conflits
+              </Link>
+            </>
           )}
           
           <Link 

--- a/src/services/actionResolutionService.ts
+++ b/src/services/actionResolutionService.ts
@@ -1,5 +1,6 @@
 import { CardInstance } from '../types/combat';
 import { Spell, SpellEffect } from '../types/index';
+import { gameConfigService } from '../utils/dataService';
 
 /**
  * @file actionResolutionService.ts
@@ -548,4 +549,46 @@ export class ActionResolutionService {
       resolutions
     };
   }
-} 
+
+  /**
+   * Charge la configuration de résolution des conflits depuis gameConfigService
+   */
+  public static async loadConfig(): Promise<{
+    strategy: ConflictResolutionStrategy;
+    randomChance: number;
+  }> {
+    try {
+      const strategyVal = await gameConfigService.getValue<string>('conflict_strategy');
+      const chanceVal = await gameConfigService.getValue<number>('conflict_random_chance');
+      return {
+        strategy: (strategyVal as ConflictResolutionStrategy) || ConflictResolutionStrategy.FIFO,
+        randomChance: chanceVal ?? 0,
+      };
+    } catch (error) {
+      console.error('Erreur chargement configuration conflits:', error);
+      return { strategy: ConflictResolutionStrategy.FIFO, randomChance: 0 };
+    }
+  }
+
+  /**
+   * Met à jour la stratégie de résolution des conflits
+   */
+  public static async updateStrategy(strategy: ConflictResolutionStrategy): Promise<void> {
+    try {
+      await gameConfigService.update('conflict_strategy', { value: strategy });
+    } catch (error) {
+      console.error('Erreur mise à jour stratégie:', error);
+    }
+  }
+
+  /**
+   * Met à jour la probabilité d'utilisation de l'aléatoire
+   */
+  public static async updateRandomChance(chance: number): Promise<void> {
+    try {
+      await gameConfigService.update('conflict_random_chance', { value: chance });
+    } catch (error) {
+      console.error('Erreur mise à jour chance aléatoire:', error);
+    }
+  }
+}

--- a/src/services/combatService.ts
+++ b/src/services/combatService.ts
@@ -797,6 +797,12 @@ export class CombatManagerImpl implements CombatManager {
     this.cardConversionService = new CardConversionService();
     this.lieuCardService = new LieuCardService();
     this.actionResolutionService = new ActionResolutionService();
+    ActionResolutionService.loadConfig().then(cfg => {
+      this.actionResolutionService.setConflictStrategy(cfg.strategy);
+      this.actionResolutionService.setRandomResolutionChance(cfg.randomChance);
+    }).catch(err => {
+      console.warn('Impossible de charger la configuration de résolution des conflits', err);
+    });
   }
 
   /**

--- a/src/utils/seedService.ts
+++ b/src/utils/seedService.ts
@@ -307,7 +307,17 @@ class SeedService {
         key: 'pv_base_initial',
         value: { value: 100 },
         description: 'Points de vie initiaux de la base'
-      }
+      },
+      {
+        key: 'conflict_strategy',
+        value: { value: 'fifo' },
+        description: 'Stratégie de résolution des conflits',
+      },
+      {
+        key: 'conflict_random_chance',
+        value: { value: 0 },
+        description: 'Probabilité de résolution aléatoire des conflits',
+      },
     ];
 
     for (const config of configs) {


### PR DESCRIPTION
## Summary
- create `ConflictSettingsPage` for admins to configure conflict strategy
- persist strategy and random chance via `gameConfigService`
- expose new route `/conflicts` behind admin check
- link to the conflicts page from the admin navigation
- load conflict settings in `CombatManagerImpl`
- update schema and seed data with new config keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431550ad08832b8b4c5802527eac37