### PR TITLE
Update cahier des charges with JSON example

### DIFF
--- a/public/TODO.md
+++ b/public/TODO.md
@@ -26,6 +26,7 @@
   - Utiliser `tagRuleParser` pour identifier les effets déclenchés et les consigner via `combatLogService`
 - [ ] Mettre en place un système d'entraînement de l'IA basé sur les simulations
   - Exécuter régulièrement `simulateGame` pour collecter des métriques et ajuster les stratégies IA
+- [x] Documenter un exemple de configuration JSON des synergies dans `cahierdescharges.md`
 
 ## 🌱 Améliorations
 - [ ] Optimiser l’interface mobile pour les petits écrans

--- a/public/cahierdescharges.md
+++ b/public/cahierdescharges.md
@@ -113,6 +113,25 @@ Les synergies constituent le cœur du système de jeu. Le moteur de règles dyna
 Configuration Facile :
 
 Définir les interactions entre tags, objets et événements via un format configurable (par exemple, des fichiers JSON ou scripts modifiables).
+Un fichier d'exemple existe dans `src/config/tagRules.json` :
+
+```json
+[
+  {
+    "tagName": "GUERRIER",
+    "rules": [
+      {
+        "name": "Bonus Attaque Guerrier",
+        "effectType": "ATTACK_MODIFIER",
+        "value": 10,
+        "isPercentage": false,
+        "targetType": "SELF"
+      }
+    ]
+  }
+]
+```
+Ces règles sont chargées par `TagRuleParserService` pour appliquer les synergies pendant le combat.
 Exemples de Synergies :
 
 Tags :


### PR DESCRIPTION
## Summary
- document JSON example for tag rules in `cahierdescharges.md`
- add a TODO item noting this documentation work

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f486754c832b8d6824fa03948a47