### PR TITLE
Implement inventory selling page

### DIFF
--- a/public/TODO.md
+++ b/public/TODO.md
@@ -33,7 +33,7 @@
   - Revoir la grille des cartes et l'affichage du GameBoard pour < 600px
 - [ ] Nettoyer le code mort et les commentaires obsolètes
   - Passer en revue les services et composants non utilisés
-- [ ] Ajouter la possibilité de vendre ses objets depuis l’interface de gestion de deck
+- [x] Ajouter la possibilité de vendre ses objets depuis l’interface de gestion de deck
   - Connecter l'UI à `PlayerInventoryService.sellItem` et mettre à jour le charisme du joueur en temps réel
 - [ ] Mettre en place l'affichage des réalisations des joueurs
   - Exploiter les tables `achievements` et `user_achievements` pour suivre la progression

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import AlterationManager from './components/AlterationManager';
 import Objectives from './components/Objectives';
 import TodoProgress from './components/TodoProgress';
 import Achievements from './components/Achievements';
+import InventoryPage from './components/InventoryPage';
 import { supabase } from './utils/supabaseClient';
 
 // Import de nos nouveaux composants UI
@@ -540,6 +541,15 @@ const AppContent: React.FC = () => {
         {/* Réalisations */}
         <Route path="/achievements" element={
           <Achievements user={user as User} />
+        } />
+
+        {/* Inventaire */}
+        <Route path="/inventory" element={
+          user ? (
+            <InventoryPage user={user as User} />
+          ) : (
+            <Navigate to="/login" replace />
+          )
         } />
 
         {/* Page d'aide */}

--- a/src/components/InventoryPage.tsx
+++ b/src/components/InventoryPage.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import InventoryManager from './InventoryManager';
+import type { Player, Card } from '../types';
+import { userService } from '../utils/userService';
+
+interface InventoryPageProps {
+  user: { id: string; username: string; currency?: number };
+}
+
+const createPlayer = (user: InventoryPageProps['user'], cards: Card[]): Player => ({
+  id: user.id,
+  name: user.username,
+  activeCard: null,
+  benchCards: [],
+  inventory: cards,
+  hand: [],
+  motivation: 0,
+  baseMotivation: 0,
+  motivationModifiers: [],
+  charisme: user.currency ?? 0,
+  baseCharisme: 0,
+  maxCharisme: 100,
+  charismeModifiers: [],
+  movementPoints: 0,
+  points: 0,
+  effects: []
+});
+
+const InventoryPage: React.FC<InventoryPageProps> = ({ user }) => {
+  const [player, setPlayer] = useState<Player | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const items = await userService.getInventory(user.id);
+        const cards: Card[] = (items || []).map((i: any) => ({ ...i.cards }));
+        setPlayer(createPlayer(user, cards));
+      } catch (err) {
+        console.error('Erreur lors du chargement de l\'inventaire:', err);
+        setPlayer(createPlayer(user, []));
+      }
+    };
+    load();
+  }, [user.id]);
+
+  const handleUpdate = async (updated: Player) => {
+    if (player) {
+      const diff = (updated.charisme || 0) - (player.charisme || 0);
+      if (diff !== 0) {
+        try {
+          await userService.updateCurrency(user.id, diff);
+        } catch (err) {
+          console.error('Erreur mise \xE0 jour du charisme:', err);
+        }
+      }
+    }
+    setPlayer(updated);
+  };
+
+  if (!player) return <div>Chargement...</div>;
+
+  return <InventoryManager player={player} onUpdate={handleUpdate} />;
+};
+
+export default InventoryPage;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export { default as ConflictResolutionManager } from './ConflictResolutionManage
 export { default as ConflictResolutionDemo } from './ConflictResolutionDemo';
 export { default as ManualTargetSelector } from './ManualTargetSelector';
 export { default as InventoryManager } from './InventoryManager';
+export { default as InventoryPage } from './InventoryPage';
 export { default as Achievements } from './Achievements';
 export { default as DebugPanel } from './DebugPanel';
 export { default as SimulationPanel } from './SimulationPanel';

--- a/src/components/ui/GameNav.tsx
+++ b/src/components/ui/GameNav.tsx
@@ -101,7 +101,14 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             className={`nav-link ${isActive('/achievements') ? 'active' : ''}`}
           >
             Succès
-              
+
+          </Link>
+          <Link
+            to="/inventory"
+            onClick={closeMobileMenu}
+            className={`nav-link ${isActive('/inventory') ? 'active' : ''}`}
+          >
+            Inventaire
           </Link>
           <Link
             to="/simulation"
@@ -214,6 +221,13 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             className={`mobile-nav-link ${isActive('/achievements') ? 'active' : ''}`}
           >
             Succès
+          </Link>
+          <Link
+            to="/inventory"
+            onClick={closeMobileMenu}
+            className={`mobile-nav-link ${isActive('/inventory') ? 'active' : ''}`}
+          >
+            Inventaire
           </Link>
           <Link
             to="/simulation"


### PR DESCRIPTION
## Summary
- add new `InventoryPage` to manage selling items from inventory
- link to inventory page in navigation
- expose page via `/inventory` route
- export `InventoryPage` in components index
- mark TODO as completed for inventory selling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847054e30e4832b9fae7d553ea61273