### PR TITLE
Fix build by removing fs dependency

### DIFF
--- a/src/components/InventoryManager.tsx
+++ b/src/components/InventoryManager.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Player, Card } from '../types';
+import type { Player, Card } from '../types/index';
 import { PlayerInventoryService } from '../services/playerInventoryService';
 import { getModifiedMaxCharisme } from '../utils/charismeService';
 import './InventoryManager.css';

--- a/src/components/InventoryPage.tsx
+++ b/src/components/InventoryPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import InventoryManager from './InventoryManager';
-import type { Player, Card } from '../types';
+import type { Player, Card } from '../types/index';
 import { userService } from '../utils/userService';
 
 interface InventoryPageProps {


### PR DESCRIPTION
## Summary
- avoid Node `fs` in tagRuleParserService
- load tag rules via JSON import
- update inventory components to import types explicitly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684716012d9c832ba8cfbda4550fcc0b