### PR TITLE
Remove spell range fields

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -41,8 +41,6 @@ interface Spell {
   description: string | null;
   power: number;
   cost: number | null;
-  range_min: number | null;
-  range_max: number | null;
   effects: SpellEffect[];
   is_value_percentage: boolean;
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -54,7 +54,6 @@ Le Yeayeayea est un outil de création et de gestion de cartes pour un jeu de ca
    - Description
    - Puissance
    - Coût
-   - Plage d'effet
    - Effets spécifiques
 
 ### 4. Gestion des Altérations

--- a/schema.sql
+++ b/schema.sql
@@ -39,8 +39,6 @@ CREATE TABLE IF NOT EXISTS public.spells (
   description text,
   power integer NOT NULL,
   cost integer,
-  range_min integer,
-  range_max integer,
   effects jsonb NOT NULL DEFAULT '[]',
   is_value_percentage boolean DEFAULT false,
   created_at timestamp with time zone DEFAULT timezone('utc'::text, now()),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ interface LoadedTagsMap {
 }
 
 interface LoadedSpellsMap {
-  [cardId: number]: { id: number; name: string; description: string | null; power: number; cost: number | null; range_min: number | null; range_max: number | null; effects: any[]; is_value_percentage: boolean }[];
+  [cardId: number]: { id: number; name: string; description: string | null; power: number; cost: number | null; effects: any[]; is_value_percentage: boolean }[];
 }
 
 interface SaveCardResult {

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -74,8 +74,6 @@ const CardPreview: React.FC<CardPreviewProps> = ({ card, spellIds = [], tagIds =
         description: spell.description || '',
         cost: spell.cost || null,
         power: spell.power,
-        range_min: spell.range_min || null,
-        range_max: spell.range_max || null,
         is_value_percentage: spell.is_value_percentage || false,
         effects: spell.effects?.map(effect => ({
           type: effect.type,

--- a/src/components/ConflictResolutionDemo.tsx
+++ b/src/components/ConflictResolutionDemo.tsx
@@ -80,8 +80,6 @@ const createMockSpells = (): Spell[] => [
     description: 'Inflige des dégâts importants',
     power: 5,
     cost: 3,
-    range_min: 1,
-    range_max: 1,
     effects: [
       { type: 'damage', value: 8 } as SpellEffect
     ],
@@ -93,8 +91,6 @@ const createMockSpells = (): Spell[] => [
     description: 'Inflige des dégâts modérés',
     power: 3,
     cost: 2,
-    range_min: 2,
-    range_max: 4,
     effects: [
       { type: 'damage', value: 5 } as SpellEffect
     ],
@@ -106,8 +102,6 @@ const createMockSpells = (): Spell[] => [
     description: 'Inflige des dégâts de zone',
     power: 6,
     cost: 4,
-    range_min: 1,
-    range_max: 3,
     effects: [
       { type: 'damage', value: 7 } as SpellEffect,
       { type: 'apply_alteration', value: 1, alteration: 1 } as SpellEffect
@@ -120,8 +114,6 @@ const createMockSpells = (): Spell[] => [
     description: 'Applique du poison à la cible',
     power: 2,
     cost: 2,
-    range_min: 1,
-    range_max: 2,
     effects: [
       { type: 'apply_alteration', value: 1, alteration: 2 } as SpellEffect
     ],

--- a/src/components/SpellList.tsx
+++ b/src/components/SpellList.tsx
@@ -70,10 +70,8 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
       description: '',
       power: 10,
       cost: 1,
-      range_min: 0,
-      range_max: 0,
-      effects: [{ 
-        type: 'damage' as const, 
+      effects: [{
+        type: 'damage' as const,
         value: 10,
         targetType: 'opponent' as const,
         chance: 100
@@ -313,29 +311,6 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
                     </div>
                   </div>
                   
-                  <div className="form-row">
-                    <div className="form-group">
-                      <label htmlFor={`spell-range-min-${spell.id}`}>Portée min</label>
-                      <input
-                        id={`spell-range-min-${spell.id}`}
-                        type="number"
-                        value={spell.range_min || 0}
-                        onChange={(e) => handleUpdateSpell(spell.id, 'range_min', parseInt(e.target.value) || 0)}
-                        className="form-input"
-                      />
-                    </div>
-                    
-                    <div className="form-group">
-                      <label htmlFor={`spell-range-max-${spell.id}`}>Portée max</label>
-                      <input
-                        id={`spell-range-max-${spell.id}`}
-                        type="number"
-                        value={spell.range_max || 0}
-                        onChange={(e) => handleUpdateSpell(spell.id, 'range_max', parseInt(e.target.value) || 0)}
-                        className="form-input"
-                      />
-                    </div>
-                  </div>
 
                   <div className="spell-effects">
                     <h4>Effets du sort</h4>

--- a/src/services/__tests__/actionResolutionService.test.ts
+++ b/src/services/__tests__/actionResolutionService.test.ts
@@ -23,8 +23,6 @@ const mockSpell: Spell = {
   description: 'Test spell description',
   power: 5,
   cost: 2,
-  range_min: 1,
-  range_max: 3,
   effects: [
     { type: 'damage', value: 3 } as SpellEffect,
     { type: 'apply_alteration', value: 1, alteration: 1 } as SpellEffect

--- a/src/services/__tests__/cardConversionService.test.ts
+++ b/src/services/__tests__/cardConversionService.test.ts
@@ -69,8 +69,6 @@ const mockSpell: Spell = {
   description: 'Lance un éclair',
   power: 5,
   cost: 2,
-  range_min: 1,
-  range_max: 3,
   effects: [{
     type: 'damage',
     value: 5

--- a/src/services/__tests__/combatService.test.ts
+++ b/src/services/__tests__/combatService.test.ts
@@ -46,8 +46,6 @@ const mockSpell: Spell = {
   description: 'Sort pour les tests',
   power: 5,
   cost: 2,
-  range_min: 1,
-  range_max: 3,
   effects: [
     {
       type: 'damage',
@@ -468,8 +466,6 @@ describe('Résolution simultanée des actions', () => {
       description: 'Test description',
       power: 5,
       cost: 2,
-      range_min: 1,
-      range_max: 3,
       effects: [
         { type: 'damage', value: 3 } as SpellEffect
       ],

--- a/src/services/characterCardService.ts
+++ b/src/services/characterCardService.ts
@@ -6,11 +6,11 @@ import { CardInstance, SpellInstance } from '../types/combat';
 // --- Mock Spell Data & Service (Placeholder) ---
 // In a real scenario, this would come from a dedicated spell service and data store.
 const mockSpellsDatabase: Map<number, Spell> = new Map([
-  [101, { id: 101, name: 'Petite Frappe', description: 'Inflige de faibles dégâts.', power: 5, cost: 1, range_min: 1, range_max: 1, effects: [{ type: 'damage', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [102, { id: 102, name: 'Mini Soin', description: 'Soigne légèrement.', power: 3, cost: 2, range_min: 0, range_max: 0, effects: [{ type: 'heal', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [105, { id: 105, name: 'Boule de Feu Basique', description: 'Une boule de feu.', power: 10, cost: 3, range_min: 1, range_max: 2, effects: [{ type: 'damage', value: 10 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [201, { id: 201, name: 'Grande Guérison', description: 'Soigne une quantité modérée de PV.', power: 15, cost: 5, range_min: 0, range_max: 0, effects: [{ type: 'heal', value: 20 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [202, { id: 202, name: 'Frappe Puissante', description: 'Une frappe plus conséquente.', power: 12, cost: 4, range_min: 1, range_max: 1, effects: [{ type: 'damage', value: 15 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [101, { id: 101, name: 'Petite Frappe', description: 'Inflige de faibles dégâts.', power: 5, cost: 1, effects: [{ type: 'damage', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [102, { id: 102, name: 'Mini Soin', description: 'Soigne légèrement.', power: 3, cost: 2, effects: [{ type: 'heal', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [105, { id: 105, name: 'Boule de Feu Basique', description: 'Une boule de feu.', power: 10, cost: 3, effects: [{ type: 'damage', value: 10 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [201, { id: 201, name: 'Grande Guérison', description: 'Soigne une quantité modérée de PV.', power: 15, cost: 5, effects: [{ type: 'heal', value: 20 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [202, { id: 202, name: 'Frappe Puissante', description: 'Une frappe plus conséquente.', power: 12, cost: 4, effects: [{ type: 'damage', value: 15 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
 ]);
 
 const mockSpellService = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,8 +80,6 @@ export interface Spell {
   description: string | null;
   power: number;
   cost: number | null;
-  range_min: number | null;
-  range_max: number | null;
   effects: SpellEffect[];
   is_value_percentage: boolean;
 }
@@ -127,5 +125,5 @@ export interface LoadedTagsMap {
 }
 
 export interface LoadedSpellsMap {
-  [cardId: number]: { id: number; name: string; description: string | null; power: number; cost: number | null; range_min: number | null; range_max: number | null; effects: any[]; is_value_percentage: boolean }[];
-} 
+  [cardId: number]: { id: number; name: string; description: string | null; power: number; cost: number | null; effects: any[]; is_value_percentage: boolean }[];
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -162,8 +162,6 @@ export interface Database {
           description: string | null;
           power: number;
           cost: number | null;
-          range_min: number | null;
-          range_max: number | null;
           effects: Json;
           is_value_percentage: boolean;
           created_at?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,8 +27,6 @@ export interface Spell {
   description: string | null;
   power: number;
   cost: number | null;
-  range_min: number | null;
-  range_max: number | null;
   effects: SpellEffect[];
   is_value_percentage: boolean;
   created_at?: string;

--- a/src/utils/seedService.ts
+++ b/src/utils/seedService.ts
@@ -56,8 +56,6 @@ class SeedService {
         description: 'Inflige des dégâts de feu',
         power: 30,
         cost: 3,
-        range_min: 1,
-        range_max: 3,
         effects: [{
           type: 'damage',
           value: 30,
@@ -70,8 +68,6 @@ class SeedService {
         description: 'Restaure des points de vie',
         power: 25,
         cost: 2,
-        range_min: 1,
-        range_max: 1,
         effects: [{
           type: 'heal',
           value: 25,


### PR DESCRIPTION
## Summary
- drop range_min/max columns from spells table
- update Spell interface and related types to remove range_min/max
- simplify default spell values and forms in `SpellList`
- stop mapping range values in `CardPreview`
- remove range fields from mock data and seed service
- adjust tests after dropping spell ranges
- update docs to reflect removal of spell range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472e590954832ba6e0279158983062