### PR TITLE
Implement disable attack effect

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -167,6 +167,27 @@ interface TagRule {
 Exemple de règle textuelle :
 `damageModifier:self:+15%:Augmente les dégâts de 15%`.
 
+Un nouvel `effectType` nommé `DISABLE_ATTACK` permet d'empêcher les cartes ciblées
+d'attaquer. Exemple dans `tagRules.json` :
+
+```json
+{
+  "tagName": "PROTECTEUR",
+  "rules": [
+    {
+      "id": 2,
+      "name": "Intimidation",
+      "description": "Empêche les Berserkers ennemis d'attaquer.",
+      "effectType": "DISABLE_ATTACK",
+      "targetType": "TAGGED",
+      "targetTag": "BERSERKER",
+      "value": 0,
+      "isPercentage": false
+    }
+  ]
+}
+```
+
 Le service gère la priorité d'application et permet de tester facilement de
 nouvelles synergies.
 

--- a/src/components/SpellList.tsx
+++ b/src/components/SpellList.tsx
@@ -25,6 +25,7 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
     { value: 'apply_alteration', label: '🔄 Appliquer altération', color: '#d1c4e9', needsValue: false, needsTarget: true },
     { value: 'add_tag', label: '🏷️ Ajouter tag', color: '#e8eaf6', needsValue: false, needsTarget: true },
     { value: 'multiply_damage', label: '✖️ Multiplier dégâts', color: '#ffecb3', needsValue: true, needsTarget: false },
+    { value: 'disable_attack', label: '🚫 Désactiver attaque', color: '#ffe0e0', needsValue: false, needsTarget: true },
     { value: 'special', label: '✨ Effet spécial', color: '#fce4ec', needsValue: false, needsTarget: false }
   ];
 

--- a/src/config/tagRules.json
+++ b/src/config/tagRules.json
@@ -30,6 +30,19 @@
         "conditions": [],
         "priority": 10,
         "sourceTag": "PROTECTEUR"
+      },
+      {
+        "id": 2,
+        "name": "Intimidation",
+        "description": "Empêche les Berserkers ennemis d'attaquer.",
+        "effectType": "DISABLE_ATTACK",
+        "value": 0,
+        "isPercentage": false,
+        "targetType": "TAGGED",
+        "targetTag": "BERSERKER",
+        "conditions": [],
+        "priority": 8,
+        "sourceTag": "PROTECTEUR"
       }
     ]
   },

--- a/src/services/__tests__/tagRuleParserService.test.ts
+++ b/src/services/__tests__/tagRuleParserService.test.ts
@@ -62,6 +62,7 @@ const createMockCardInstance = (card: TestCard, id: string = `player1_${card.id}
     availableSpells: [],
     isExhausted: false,
     isTapped: false,
+    unableToAttack: false,
     counters: {},
     
     // Implémentations simplifiées des méthodes requises
@@ -408,6 +409,29 @@ describe('TagRuleParserService', () => {
 
       expect(results[0].success).toBe(true);
       expect(sourceCard.temporaryStats.defense).toBe(6); // 4 + 50% of base (4) => +2
+    });
+
+    test("Devrait désactiver l'attaque des cibles", () => {
+      const rule: TagRule = {
+        name: 'Intimidation',
+        description: 'Empêche la cible d\'attaquer',
+        effectType: TagRuleEffectType.DISABLE_ATTACK,
+        value: 0,
+        isPercentage: false,
+        targetType: TagRuleTargetType.TAGGED,
+        targetTag: 'FRAGILE'
+      };
+
+      parserService.addRuleForTag('JOUR', rule);
+
+      const sourceCard = mockCardInstances[1]; // player1_2 avec tag JOUR
+      const targetCard = mockCardInstances[0];
+
+      const results = parserService.applyTagRules('JOUR', sourceCard, mockCardInstances, mockGameState);
+
+      expect(results[0].success).toBe(true);
+      // @ts-ignore - property added dynamically
+      expect(targetCard.unableToAttack).toBe(true);
     });
   });
 });

--- a/src/services/combatService.ts
+++ b/src/services/combatService.ts
@@ -72,6 +72,9 @@ export class CardInstanceImpl implements CardInstance {
   
   /** Indique si la carte est inclinée (pour les actions spéciales) */
   public isTapped: boolean;
+
+  /** Indique si la carte est empêchée d'attaquer */
+  public unableToAttack: boolean;
   
   /** Compteurs spécifiques */
   public counters: { [key: string]: number };
@@ -109,6 +112,7 @@ export class CardInstanceImpl implements CardInstance {
     // Initialiser les états
     this.isExhausted = false;
     this.isTapped = false;
+    this.unableToAttack = false;
     
     // Initialiser les compteurs
     this.counters = {};
@@ -291,7 +295,7 @@ export class CardInstanceImpl implements CardInstance {
    * @returns Vrai si la carte peut attaquer, faux sinon
    */
   public canAttack(): boolean {
-    return !this.isExhausted && !this.isTapped && this.currentHealth > 0;
+    return !this.isExhausted && !this.isTapped && !this.unableToAttack && this.currentHealth > 0;
   }
 
   /**
@@ -320,6 +324,7 @@ export class CardInstanceImpl implements CardInstance {
     // Réinitialiser l'état d'épuisement
     this.isExhausted = false;
     this.isTapped = false;
+    this.unableToAttack = false;
     
     // Réduire la durée des altérations et supprimer celles expirées
     const alterationsBeforeUpdate = [...this.activeAlterations];

--- a/src/services/tagRuleParserService.ts
+++ b/src/services/tagRuleParserService.ts
@@ -270,6 +270,9 @@ export class TagRuleParserService {
 
       case TagRuleEffectType.DEFENSE_MODIFIER:
         return this.applyDefenseModifierEffect(rule, sourceCard, targets, result, gameState);
+
+      case TagRuleEffectType.DISABLE_ATTACK:
+        return this.applyDisableAttackEffect(rule, sourceCard, targets, result, gameState);
       // --- End new effect types ---
       
       default:
@@ -525,6 +528,23 @@ export class TagRuleParserService {
         source: `Tag: ${result.sourceTag} (Rule: ${rule.name})`,
         isPercentage: rule.isPercentage,
       });
+    }
+    result.success = true;
+    return result;
+  }
+
+  /**
+   * Applique un effet désactivant la capacité d'attaque des cartes ciblées.
+   */
+  private applyDisableAttackEffect(
+    rule: TagRule,
+    sourceCard: CardInstance,
+    targets: CardInstance[],
+    result: TagRuleApplicationResult,
+    gameState: any
+  ): TagRuleApplicationResult {
+    for (const target of targets) {
+      (target as any).unableToAttack = true;
     }
     result.success = true;
     return result;

--- a/src/tests/services/attackConditionsService.test.ts
+++ b/src/tests/services/attackConditionsService.test.ts
@@ -28,6 +28,7 @@ const mockCardInstance = (canAttackResult = true): CardInstance => ({
   availableSpells: [],
   isExhausted: false,
   isTapped: false,
+  unableToAttack: false,
   counters: {},
   damageHistory: [],
   activeEffects: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,8 @@ export type SpellEffectType =
   | 'add_tag'
   | 'multiply_damage'
   | 'shield'
-  | 'apply_alteration';
+  | 'apply_alteration'
+  | 'disable_attack';
 
 export interface SpellEffect {
   type: SpellEffectType;

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -77,6 +77,7 @@ export interface CardInstance {
   // État de la carte
   isExhausted: boolean; // Si la carte a déjà été utilisée ce tour
   isTapped: boolean;    // Si la carte est inclinée (pour les actions spéciales)
+  unableToAttack?: boolean; // Effet temporaire empêchant d'attaquer
   
   // Compteurs spécifiques
   counters: {

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -15,6 +15,7 @@ export enum TagRuleEffectType {
   APPLY_ALTERATION = 'applyAlteration',       // Applique une altération
   CONDITIONAL_EFFECT = 'conditionalEffect',   // Effet qui s'applique sous condition
   SYNERGY_EFFECT = 'synergyEffect',           // Effet qui s'applique en fonction d'autres tags
+  DISABLE_ATTACK = 'disableAttack',           // Empêche les cartes ciblées d'attaquer
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend `SpellEffectType` and `TagRuleEffectType` with `disable_attack`
- add handling in `TagRuleParserService` to mark targets as unable to attack
- expose the effect in `SpellList` editor
- allow target tag in config and show example in docs
- support new flag on `CardInstance` and update combat logic
- update tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68472e5d858c832ba94ffeb127637ed0