### PR TITLE
Refactor effect editor

### DIFF
--- a/src/components/SpellList.css
+++ b/src/components/SpellList.css
@@ -256,6 +256,12 @@
   cursor: not-allowed;
 }
 
+.effect-help {
+  margin-left: 6px;
+  cursor: help;
+  font-weight: bold;
+}
+
 @media (max-width: 768px) {
   .form-row {
     flex-direction: column;

--- a/src/components/SpellList.tsx
+++ b/src/components/SpellList.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Spell, SpellEffect } from '../types';
 import { spellService } from '../utils/dataService';
 import AlterationSelector from './AlterationSelector';
+import { effectTypes } from '../utils/effectTypes';
 import './SpellList.css';
 
 interface SpellListProps {
@@ -15,18 +16,6 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
   const [expandedSpellId, setExpandedSpellId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [editingEffect, setEditingEffect] = useState<{spellIndex: number, effectIndex: number} | null>(null);
-
-  // Effect types with their visual properties
-  const effectTypes = [
-    { value: 'damage', label: '⚔️ Dégâts', color: '#ffebee', needsValue: true, needsTarget: true },
-    { value: 'heal', label: '💚 Soin', color: '#e8f5e9', needsValue: true, needsTarget: true },
-    { value: 'draw', label: '🃏 Piocher', color: '#e3f2fd', needsValue: true, needsTarget: false },
-    { value: 'resource', label: '⚡ Ressource', color: '#e0f2f1', needsValue: true, needsTarget: true },
-    { value: 'apply_alteration', label: '🔄 Appliquer altération', color: '#d1c4e9', needsValue: false, needsTarget: true },
-    { value: 'add_tag', label: '🏷️ Ajouter tag', color: '#e8eaf6', needsValue: false, needsTarget: true },
-    { value: 'multiply_damage', label: '✖️ Multiplier dégâts', color: '#ffecb3', needsValue: true, needsTarget: false },
-    { value: 'special', label: '✨ Effet spécial', color: '#fce4ec', needsValue: false, needsTarget: false }
-  ];
 
   const loadSpells = useCallback(async () => {
     if (spellIds.length === 0) {
@@ -357,6 +346,12 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
                               </option>
                             ))}
                           </select>
+                          <span
+                            className="effect-help"
+                            title={effectTypes.find(t => t.value === effect.type)?.help}
+                          >
+                            ?
+                          </span>
                           <button
                             onClick={() => handleRemoveEffect(spell.id, effectIndex)}
                             className="remove-effect-button"
@@ -368,13 +363,15 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
 
                         {effectTypes.find(t => t.value === effect.type)?.needsValue && (
                           <div className="effect-value">
-                            <input
-                              type="number"
-                              value={effect.value || 0}
-                              onChange={(e) => handleUpdateEffect(spell.id, effectIndex, 'value', parseInt(e.target.value) || 0)}
-                              placeholder="Valeur"
-                              className="effect-input"
-                            />
+                            <label>
+                              Puissance
+                              <input
+                                type="number"
+                                value={effect.value || 0}
+                                onChange={(e) => handleUpdateEffect(spell.id, effectIndex, 'value', parseInt(e.target.value) || 0)}
+                                className="effect-input"
+                              />
+                            </label>
                           </div>
                         )}
 

--- a/src/tests/utils/validation.test.ts
+++ b/src/tests/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { validateCardSync } from '../../utils/validation';
+import { validateCardSync, validateSpell } from '../../utils/validation';
 import { Card } from '../../types';
 
 describe('validateCardSync', () => {
@@ -337,4 +337,33 @@ describe('validateCardSync', () => {
       expect(errors).toContain('Le coût d\'invocation doit être positif même pour les cartes "cheate"');
     });
   });
-}); 
+});
+
+describe('validateSpell', () => {
+  const baseSpell = {
+    id: 1,
+    name: 'Test',
+    description: '',
+    power: 1,
+    cost: 1,
+    range_min: 0,
+    range_max: 0,
+    is_value_percentage: false,
+  };
+
+  it('requires value when effect needs it', () => {
+    const errors = validateSpell({
+      ...baseSpell,
+      effects: [{ type: 'damage', value: NaN, targetType: 'self' }],
+    });
+    expect(errors).toContain('Effet #1: La valeur doit être un nombre');
+  });
+
+  it('does not require value for effects without needsValue', () => {
+    const errors = validateSpell({
+      ...baseSpell,
+      effects: [{ type: 'apply_alteration', alteration: 1, targetType: 'self' }],
+    });
+    expect(errors.find(e => e.includes('valeur'))).toBeUndefined();
+  });
+});

--- a/src/utils/effectTypes.ts
+++ b/src/utils/effectTypes.ts
@@ -1,0 +1,19 @@
+export interface EffectTypeDefinition {
+  value: 'damage' | 'heal' | 'draw' | 'resource' | 'add_tag' | 'multiply_damage' | 'apply_alteration' | 'special';
+  label: string;
+  color: string;
+  needsValue: boolean;
+  needsTarget: boolean;
+  help: string;
+}
+
+export const effectTypes: EffectTypeDefinition[] = [
+  { value: 'damage', label: '⚔️ Dégâts', color: '#ffebee', needsValue: true, needsTarget: true, help: "Inflige des dégâts à la cible" },
+  { value: 'heal', label: '💚 Soin', color: '#e8f5e9', needsValue: true, needsTarget: true, help: "Soigne la cible" },
+  { value: 'draw', label: '🃏 Piocher', color: '#e3f2fd', needsValue: true, needsTarget: false, help: "Pioche des cartes" },
+  { value: 'resource', label: '⚡ Ressource', color: '#e0f2f1', needsValue: true, needsTarget: true, help: "Génère ou coûte de la ressource" },
+  { value: 'apply_alteration', label: '🔄 Appliquer altération', color: '#d1c4e9', needsValue: false, needsTarget: true, help: "Applique une altération spécifique" },
+  { value: 'add_tag', label: '🏷️ Ajouter tag', color: '#e8eaf6', needsValue: false, needsTarget: true, help: "Ajoute un tag à la cible" },
+  { value: 'multiply_damage', label: '✖️ Multiplier dégâts', color: '#ffecb3', needsValue: true, needsTarget: false, help: "Multiplie les dégâts" },
+  { value: 'special', label: '✨ Effet spécial', color: '#fce4ec', needsValue: false, needsTarget: false, help: "Effet personnalisé" },
+];

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,5 @@
 import { Card, Spell, Tag } from '../types';
+import { effectTypes } from './effectTypes';
 import { Json } from '../types/database.types';
 import { spellService, tagService } from './dataService';
 import { supabase } from './supabaseClient';
@@ -230,11 +231,25 @@ export const validateSpell = (spell: Spell): string[] => {
 
   if (spell.effects) {
     spell.effects.forEach((effect, index) => {
-      if (!effect.type) errors.push(`Effet #${index + 1}: Le type est requis`);
-      if (typeof effect.value !== 'number') errors.push(`Effet #${index + 1}: La valeur doit être un nombre`);
+      if (!effect.type) {
+        errors.push(`Effet #${index + 1}: Le type est requis`);
+        return;
+      }
+
+      const def = effectTypes.find(t => t.value === effect.type);
+
+      if (def?.needsValue && typeof effect.value !== 'number') {
+        errors.push(`Effet #${index + 1}: La valeur doit être un nombre`);
+      }
+
+      if (def?.needsTarget && !effect.targetType) {
+        errors.push(`Effet #${index + 1}: La cible est requise`);
+      }
+
       if (effect.type === 'add_tag' && !effect.tagTarget) {
         errors.push(`Effet #${index + 1}: Un tag cible est requis pour l'effet add_tag`);
       }
+
       if (effect.type === 'apply_alteration' && !effect.alteration) {
         errors.push(`Effet #${index + 1}: Une altération est requise pour l'effet apply_alteration`);
       }


### PR DESCRIPTION
## Summary
- move effect type definitions to reusable module
- show info tooltip for effect types
- hide power input when effect type doesn't use it
- validate effect fields based on new metadata
- test spell validation logic

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68472e5f4bec832b8ef1b769088c8653