### PR TITLE
Fix build error and update validation tests

### DIFF
--- a/src/components/SpellList.tsx
+++ b/src/components/SpellList.tsx
@@ -447,7 +447,7 @@ const SpellList: React.FC<SpellListProps> = ({ spellIds, onChange, maxSpells }) 
                                     onChange={(e) => handleUpdateSubEffect(spell.id, effectIndex, subIndex, 'type', e.target.value)}
                                     className="effect-type-select"
                                   >
-                                    {effectTypes.filter(t => t.value !== 'choice').map(type => (
+                                    {effectTypes.map(type => (
                                       <option key={type.value} value={type.value}>{type.label}</option>
                                     ))}
                                   </select>

--- a/src/services/characterCardService.ts
+++ b/src/services/characterCardService.ts
@@ -6,11 +6,11 @@ import { CardInstance, SpellInstance } from '../types/combat';
 // --- Mock Spell Data & Service (Placeholder) ---
 // In a real scenario, this would come from a dedicated spell service and data store.
 const mockSpellsDatabase: Map<number, Spell> = new Map([
-  [101, { id: 101, name: 'Petite Frappe', description: 'Inflige de faibles dégâts.', effects: [{ type: 'damage', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [102, { id: 102, name: 'Mini Soin', description: 'Soigne légèrement.', effects: [{ type: 'heal', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [105, { id: 105, name: 'Boule de Feu Basique', description: 'Une boule de feu.', effects: [{ type: 'damage', value: 10 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [201, { id: 201, name: 'Grande Guérison', description: 'Soigne une quantité modérée de PV.', effects: [{ type: 'heal', value: 20 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
-  [202, { id: 202, name: 'Frappe Puissante', description: 'Une frappe plus conséquente.', effects: [{ type: 'damage', value: 15 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [101, { id: 101, name: 'Petite Frappe', description: 'Inflige de faibles dégâts.', cost: 0, effects: [{ type: 'damage', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [102, { id: 102, name: 'Mini Soin', description: 'Soigne légèrement.', cost: 0, effects: [{ type: 'heal', value: 5 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [105, { id: 105, name: 'Boule de Feu Basique', description: 'Une boule de feu.', cost: 0, effects: [{ type: 'damage', value: 10 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [201, { id: 201, name: 'Grande Guérison', description: 'Soigne une quantité modérée de PV.', cost: 0, effects: [{ type: 'heal', value: 20 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
+  [202, { id: 202, name: 'Frappe Puissante', description: 'Une frappe plus conséquente.', cost: 0, effects: [{ type: 'damage', value: 15 }], is_value_percentage: false, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }],
 ]);
 
 const mockSpellService = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,8 @@ export type SpellEffectType =
   | 'multiply_damage'
   | 'shield'
   | 'apply_alteration'
-  | 'choice';
+  | 'special'
+  | 'choice'
   | 'disable_attack';
 
 export interface WeightedSpellEffect {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,7 +41,7 @@ export interface WeightedSpellEffect {
 }
 
 export interface SpellEffect {
-  type: 'damage' | 'heal' | 'draw' | 'resource' | 'add_tag' | 'multiply_damage' | 'apply_alteration' | 'choice';
+  type: 'damage' | 'heal' | 'draw' | 'resource' | 'add_tag' | 'multiply_damage' | 'apply_alteration' | 'special' | 'choice' | 'disable_attack';
   value?: number;
   targetType?: 'self' | 'opponent' | 'all' | 'tagged' | 'manual';
   tagTarget?: string;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -237,7 +237,7 @@ export const validateSpell = (spell: Spell): string[] => {
 
       const def = effectTypes.find(t => t.value === effect.type);
 
-      if (def?.needsValue && typeof effect.value !== 'number') {
+      if (def?.needsValue && (typeof effect.value !== 'number' || isNaN(effect.value))) {
         errors.push(`Effet #${index + 1}: La valeur doit être un nombre`);
       }
 


### PR DESCRIPTION
## Summary
- allow all effect types in SpellList dropdown
- extend SpellEffect types
- require numeric values in spell validation
- define cost for mock spells so typings match

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684737b4f170832bad8a5178e34cc7ae