### PR TITLE
Enable direct image upload for cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Yeayeayea is a web application for building and managing trading card game data.
 - npm
 
 Environment variables are read from a `.env` file. Example configuration is provided in the repository. Adjust the Supabase keys and other values to match your setup. When running in production, the `SESSION_SECRET` variable **must** be set or the Express server will exit with an error.
+If you plan to upload card images directly, create a Supabase Storage bucket named `card-images` and ensure your anon key has write access. The bucket must allow public read access or the preview will fail with 404 errors.
 
 
 ## Installation

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,7 +15,7 @@ Le Yeayeayea est un outil de création et de gestion de cartes pour un jeu de ca
    - Type (personnage, objet, événement, lieu, action)
    - Rareté (gros_bodycount, interessant, banger, cheate)
    - Description
-   - Image (URL)
+   - Image (URL ou fichier à téléverser)
    - Effet passif
    - Coût d'invocation
    - Propriétés spécifiques (PV, etc.)
@@ -129,6 +129,7 @@ Lors de l'exécution, un des sous-effets est sélectionné selon son poids.
 3. **Qualité**
    - Vérifiez les descriptions
    - Assurez-vous que les images sont de bonne qualité
+   - Vous pouvez téléverser une image locale : le formulaire l'enverra dans Supabase, remplira automatiquement l'URL et la prévisualisation se mettra à jour
    - Testez les interactions entre cartes
 
 ## Support

--- a/src/components/CardForm.tsx
+++ b/src/components/CardForm.tsx
@@ -4,7 +4,7 @@ import type { Card } from '../types';
 import SpellList from './SpellList';
 import TagList from './TagList';
 import CardPreview from './CardPreview';
-import { updateCard, insertCard } from '../utils/supabaseClient';
+import { updateCard, insertCard, uploadCardImage } from '../utils/supabaseClient';
 import { updateCardSpells, updateCardTags } from '../utils/supabaseUtils';
 import { getCardSpells, getCardTags } from '../utils/validation';
 import './CardForm.css';
@@ -187,6 +187,23 @@ const CardForm: React.FC<CardFormProps> = ({
       setTimeout(() => saveToDatabase(cardToSave), 500);
     }
   }, [saveToDatabase]);
+
+  const handleImageFile = async (file: File) => {
+    // Prévisualiser immédiatement l'image choisie
+    const localUrl = URL.createObjectURL(file);
+    setLocalCard(prev => ({ ...prev, image: localUrl }));
+    refreshPreview();
+    try {
+      const url = await uploadCardImage(file);
+      URL.revokeObjectURL(localUrl);
+      setLocalCard(prev => ({ ...prev, image: url }));
+      refreshPreview();
+      showToast('Image uploadée avec succès', 'success');
+    } catch (err) {
+      console.error('Erreur lors de l\'upload de l\'image:', err);
+      showToast('Erreur lors de l\'upload de l\'image', 'error');
+    }
+  };
 
   const handleChange = (e: CardInputEvent) => {
     const { name, value, type } = e.target;
@@ -532,6 +549,14 @@ const CardForm: React.FC<CardFormProps> = ({
                     onChange={handleChange}
                     placeholder="URL de l'image"
                     className="form-input"
+                  />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleImageFile(file);
+                    }}
                   />
                 </div>
 

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -23,6 +23,29 @@ if (!supabaseUrl || !supabaseKey) {
 export const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
 /**
+ * Upload an image file to Supabase Storage and return its public URL.
+ * The file is uploaded to the `card-images` bucket.
+ * @param file The image file to upload
+ * @returns The public URL of the uploaded image
+ */
+export const uploadCardImage = async (file: File): Promise<string> => {
+  const bucket = 'card-images';
+  const extension = file.name.split('.').pop();
+  const fileName = `${Date.now()}.${extension}`;
+
+  const { error } = await supabase.storage.from(bucket).upload(fileName, file, {
+    contentType: file.type,
+    cacheControl: '3600',
+  });
+  if (error) {
+    throw error;
+  }
+
+  const { data } = supabase.storage.from(bucket).getPublicUrl(fileName);
+  return data.publicUrl;
+};
+
+/**
  * Sauvegarde une carte dans la base de données (création ou mise à jour)
  * @param card - La carte à sauvegarder
  * @returns Un objet contenant la carte sauvegardée ou une erreur


### PR DESCRIPTION
## Summary
- allow uploading image files in card form
- handle image upload via supabase storage
- document new ability in user guide
- mention storage bucket requirement in README
- refresh preview after upload and add local preview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847482af174832b9d6fd85c3ed41b87