### PR TITLE
Fix event duration field handling

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -14,7 +14,7 @@
   - `passive_effect`: Effet passif de la carte
   - `properties`: Propriétés spécifiques (points de vie, etc.)
   - `summon_cost`: Coût d'invocation
-  - `eventDuration`: Pour les cartes `evenement`, indique si l'effet est `instantanee`, `temporaire` ou `permanente`
+  - `event_duration` (exposé comme `eventDuration` côté client) : pour les cartes `evenement`, indique si l'effet est `instantanee`, `temporaire` ou `permanente`
   - `is_wip`: Indique si la carte est en cours de développement
   - `is_crap`: Indique si la carte est à retravailler
 

--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS public.cards (
   description text,
   type text NOT NULL CHECK (type IN ('personnage', 'objet', 'evenement', 'lieu', 'action')),
   rarity text NOT NULL,
+  event_duration text CHECK (event_duration IN ('instantanee', 'temporaire', 'permanente')),
   properties jsonb DEFAULT '{}',
   summon_cost integer, -- Nouveau: coût en charisme pour les cartes invoquables
   image text,

--- a/src/tests/services/cardCrudOperations.test.ts
+++ b/src/tests/services/cardCrudOperations.test.ts
@@ -50,6 +50,7 @@ const mockCardRow: CardRow = {
   description: 'A card for testing',
   type: 'personnage',
   rarity: 'commun',
+  event_duration: null,
   properties: { hp: 10, attack: 5 },
   summon_cost: 3,
   image: null,
@@ -109,6 +110,7 @@ describe('Card CRUD Operations', () => {
       // Utiliser un type valide afin d'éviter une erreur de compilation
       type: 'action',
       rarity: 'rare',
+      event_duration: null,
       properties: { mana_cost: 4 },
       summon_cost: 0, // Assuming 0 for sort type or if not applicable
       image: null,

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -81,6 +81,7 @@ export interface Database {
           description: string | null;
           type: 'personnage' | 'objet' | 'evenement' | 'lieu' | 'action';
           rarity: string;
+          event_duration: 'instantanee' | 'temporaire' | 'permanente' | null;
           properties: Json;
           summon_cost: number | null;  // Nouveau: coût en charisme pour les cartes invoquables
           image: string | null;
@@ -90,7 +91,9 @@ export interface Database {
           created_at?: string;
           updated_at?: string;
         }
-        Insert: Omit<Database['public']['Tables']['cards']['Row'], 'id' | 'created_at' | 'updated_at'>
+        Insert: Omit<Database['public']['Tables']['cards']['Row'], 'id' | 'created_at' | 'updated_at' | 'event_duration'> & {
+          event_duration?: 'instantanee' | 'temporaire' | 'permanente' | null
+        }
         Update: Partial<Database['public']['Tables']['cards']['Insert']>
       },
       users: {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,6 +4,7 @@ import { Card, CardFrontend } from '../types';
 export const normalizeCardForFrontend = (card: Card): CardFrontend => {
   return {
     ...card,
+    eventDuration: (card as any).event_duration ?? card.eventDuration,
     // Create virtual properties that map to the database fields
     isWIP: card.is_wip,
     isCrap: card.is_crap,
@@ -15,12 +16,15 @@ export const normalizeCardForFrontend = (card: Card): CardFrontend => {
   };
 };
 
-export const normalizeCardForDatabase = (card: CardFrontend): Omit<Card, 'id'> => {
+export const normalizeCardForDatabase = (
+  card: CardFrontend
+): Omit<Card, 'id' | 'eventDuration'> & { event_duration?: Card['eventDuration'] } => {
   // Extract only the properties that should be saved to the database
   const { isWIP, isCrap, passiveEffect, spells, tags, ...rest } = card;
-  
+
   return {
     ...rest,
+    event_duration: card.eventDuration,
     is_wip: isWIP,
     is_crap: isCrap,
     passive_effect: passiveEffect,


### PR DESCRIPTION
## Summary
- add event_duration column in schema
- map eventDuration to event_duration in DB helpers
- normalize eventDuration conversion helpers
- update database types and docs
- fix tests for new field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68475d3abe30832bbf4b71d41c1ab397