### PR TITLE
Add unit tests for utilities and scripts

### DIFF
--- a/src/scripts/seedDatabase.ts
+++ b/src/scripts/seedDatabase.ts
@@ -13,4 +13,6 @@ async function main() {
 
 if (require.main === module) {
   main();
-} 
+}
+
+export { main };

--- a/src/tests/scripts/seedDatabase.test.ts
+++ b/src/tests/scripts/seedDatabase.test.ts
@@ -1,0 +1,42 @@
+import { seedService } from '../../utils/seedService';
+import { main } from '../../scripts/seedDatabase';
+
+jest.mock('../../utils/seedService', () => ({
+  seedService: {
+    seedAll: jest.fn()
+  }
+}));
+
+describe('seedDatabase script', () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const exitMock = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    (seedService.seedAll as jest.Mock).mockReset();
+    console.log = jest.fn();
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    exitMock.mockClear();
+  });
+
+  afterAll(() => {
+    exitMock.mockRestore();
+  });
+
+  it('runs seed successfully', async () => {
+    (seedService.seedAll as jest.Mock).mockResolvedValue(undefined);
+    await main();
+    expect(seedService.seedAll).toHaveBeenCalled();
+  });
+
+  it('handles errors', async () => {
+    (seedService.seedAll as jest.Mock).mockRejectedValue(new Error('boom'));
+    await main();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/tests/server/auth.test.ts
+++ b/src/tests/server/auth.test.ts
@@ -1,0 +1,33 @@
+process.env.JWT_SECRET = 'test';
+process.env.REACT_APP_SUPABASE_URL = 'http://localhost';
+process.env.REACT_APP_SUPABASE_ANON_KEY = 'anon';
+
+import { authenticateToken, requireAdmin } from '../../server/auth';
+import jwt from 'jsonwebtoken';
+
+describe('auth middleware', () => {
+  it('rejects when token missing', () => {
+    const req: any = { headers: {} };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects when token invalid', () => {
+    jest.spyOn(jwt as any, 'verify').mockImplementation((t: any, s: any, cb: any) => cb(new Error('bad')));
+    const req: any = { headers: { authorization: 'Bearer x' } };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('passes when admin', () => {
+    const req: any = { user: { isAdmin: true } };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    requireAdmin(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/tests/ui/Achievements.test.tsx
+++ b/src/tests/ui/Achievements.test.tsx
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import Achievements from '../../components/Achievements';
+import { userService } from '../../utils/userService';
+import { supabase } from '../../utils/supabaseClient';
+
+jest.mock('../../utils/userService');
+jest.mock('../../utils/supabaseClient');
+
+describe('Achievements component', () => {
+  it('renders unlocked and locked achievements', async () => {
+    (userService.getAchievements as jest.Mock).mockResolvedValue([{ achievements: { id: 1, name: 'A1', description: 'd', icon_url: '' } }]);
+    (supabase.from as jest.Mock).mockReturnValue({ select: jest.fn().mockResolvedValue({ data: [{ id:1,name:'A1',description:'d'},{ id:2,name:'A2',description:'e'}], error: null }) });
+
+    const { getByText } = render(<Achievements user={{ id: 'u' }} />);
+    await waitFor(() => getByText('Réalisations'));
+
+    expect(getByText('A1')).toBeInTheDocument();
+    expect(getByText('A2')).toBeInTheDocument();
+  });
+});

--- a/src/tests/utils/dataService.test.ts
+++ b/src/tests/utils/dataService.test.ts
@@ -1,0 +1,28 @@
+import { joinTableService } from '../../utils/dataService';
+import { mockSupabase } from '../mocks/supabase';
+
+const mockFrom = mockSupabase.from as jest.Mock;
+
+describe('dataService joinTableService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getTagsByCardId returns tag ids', async () => {
+    const selectMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ data: [{ tag_id: 1 }], error: null }) });
+    mockFrom.mockReturnValue({ select: selectMock } as any);
+
+    const result = await joinTableService.getTagsByCardId(1);
+    expect(mockFrom).toHaveBeenCalledWith('card_tags');
+    expect(result).toEqual([{ tag_id: 1 }]);
+  });
+
+  it('getSpellsByCardId returns spell ids', async () => {
+    const selectMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ data: [{ spell_id: 2 }], error: null }) });
+    mockFrom.mockReturnValue({ select: selectMock } as any);
+
+    const result = await joinTableService.getSpellsByCardId(1);
+    expect(mockFrom).toHaveBeenCalledWith('card_spells');
+    expect(result).toEqual([{ spell_id: 2 }]);
+  });
+});

--- a/src/tests/utils/effectTypes.test.ts
+++ b/src/tests/utils/effectTypes.test.ts
@@ -1,0 +1,12 @@
+import { effectTypes } from '../../utils/effectTypes';
+
+describe('effectTypes', () => {
+  it('contains expected effect definitions', () => {
+    const damage = effectTypes.find(e => e.value === 'damage');
+    const heal = effectTypes.find(e => e.value === 'heal');
+    expect(damage).toBeTruthy();
+    expect(heal).toBeTruthy();
+    expect(damage?.needsTarget).toBe(true);
+    expect(heal?.needsValue).toBe(true);
+  });
+});

--- a/src/tests/utils/githubService.test.ts
+++ b/src/tests/utils/githubService.test.ts
@@ -1,0 +1,43 @@
+import { Octokit } from '@octokit/rest';
+
+declare const global: any;
+
+jest.mock('@octokit/rest', () => ({
+  __esModule: true,
+  Octokit: jest.fn().mockImplementation(() => ({
+    repos: { getContent: jest.fn(), createOrUpdateFileContents: jest.fn() },
+    users: { getAuthenticated: jest.fn() }
+  }))
+}));
+
+const mockedOctokit = Octokit as unknown as jest.Mock;
+let githubService: any;
+
+beforeEach(() => {
+  jest.resetModules();
+  mockedOctokit.mockClear();
+  global.localStorage = {
+    getItem: jest.fn().mockReturnValue(null),
+    setItem: jest.fn()
+  };
+});
+
+describe('githubService', () => {
+  it('setToken stores token', () => {
+    githubService = require('../../utils/githubService').githubService;
+    githubService.setToken('abc');
+    expect(global.localStorage.setItem).toHaveBeenCalledWith('github_token', 'abc');
+  });
+
+  it('isAuthenticated returns true when API succeeds', async () => {
+    const mockInstance = {
+      repos: { getContent: jest.fn(), createOrUpdateFileContents: jest.fn() },
+      users: { getAuthenticated: jest.fn().mockResolvedValue({}) }
+    };
+    mockedOctokit.mockReturnValue(mockInstance as any);
+    githubService = require('../../utils/githubService').githubService;
+    githubService.setToken('t');
+    const result = await githubService.isAuthenticated();
+    expect(result).toBe(true);
+  });
+});

--- a/src/tests/utils/spellService.test.ts
+++ b/src/tests/utils/spellService.test.ts
@@ -1,0 +1,32 @@
+import { getById, getByIds } from '../../utils/spellService';
+import { mockSupabase } from '../mocks/supabase';
+import { setupMockFrom } from '../utils/testUtils';
+
+const mockFrom = mockSupabase.from as jest.Mock;
+
+describe('spellService util', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getById returns spell data', async () => {
+    const { mock: fromMock, helpers } = setupMockFrom();
+    const spell = { id: 1, name: 'fire', effects: '[]' };
+    helpers.mockSingleSuccess(spell);
+    mockFrom.mockImplementation(() => fromMock());
+
+    const result = await getById(1);
+    expect(mockFrom).toHaveBeenCalledWith('spells');
+    expect(result).toEqual(spell);
+  });
+
+  it('getByIds returns list of spells', async () => {
+    const spells = [{ id:1, effects:'[]' }, { id:2, effects:'[]' }];
+    const selectMock = jest.fn().mockReturnValue({ in: jest.fn().mockResolvedValue({ data: spells, error: null }) });
+    mockFrom.mockReturnValue({ select: selectMock } as any);
+
+    const result = await getByIds([{ spell_id: 1 }, { spell_id: 2 }]);
+    expect(selectMock).toHaveBeenCalled();
+    expect(result).toEqual(spells);
+  });
+});

--- a/src/tests/utils/supabaseUtils.test.ts
+++ b/src/tests/utils/supabaseUtils.test.ts
@@ -1,0 +1,37 @@
+import { updateCardSpells, updateCardTags } from '../../utils/supabaseUtils';
+import { mockSupabase } from '../mocks/supabase';
+import { setupMockFrom } from '../utils/testUtils';
+
+const mockFrom = mockSupabase.from as jest.Mock;
+
+describe('supabaseUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('updateCardSpells', () => {
+    it('deletes existing relations and inserts new ones', async () => {
+      const { mock: fromMock, helpers } = setupMockFrom();
+      mockFrom.mockImplementation(() => fromMock());
+
+      await updateCardSpells(1, [2,3]);
+
+      expect(mockFrom).toHaveBeenCalledWith('card_spells');
+      expect(helpers.delete).toHaveBeenCalled();
+      expect(helpers.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateCardTags', () => {
+    it('deletes existing relations and inserts new ones', async () => {
+      const { mock: fromMock, helpers } = setupMockFrom();
+      mockFrom.mockImplementation(() => fromMock());
+
+      await updateCardTags(1, [4]);
+
+      expect(mockFrom).toHaveBeenCalledWith('card_tags');
+      expect(helpers.delete).toHaveBeenCalled();
+      expect(helpers.insert).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export `main` from `seedDatabase.ts`
- add unit tests for supabase utils, spell service, data service join tables, and effectTypes
- cover GitHub service, Achievements component and auth middleware
- test seedDatabase script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68476a558458832bba84324f94afde46