### PR TITLE
Implémentation partielle du TODO

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './GameBoard.css';
 import { Card, CardFrontend } from '../types/index';
 import { CardInstance } from '../types/combat';
 import { PlayerBase } from '../types/player';
 import PlayerBaseComponent from './PlayerBase';
+import { gameConfigService } from '../utils/dataService';
 
 interface GameBoardProps {
   // Propriétés du joueur
@@ -62,6 +63,18 @@ const GameBoard: React.FC<GameBoardProps> = ({
 }) => {
   // État pour le glisser-déposer
   const [draggedCard, setDraggedCard] = useState<Card | null>(null);
+  const [maxCharacters, setMaxCharacters] = useState<number>(3);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const val = await gameConfigService.getValue<number>('max_personnages');
+        if (val) setMaxCharacters(val);
+      } catch (e) {
+        console.warn('Configuration max_personnages indisponible:', e);
+      }
+    })();
+  }, []);
 
   // Gestionnaires d'événements pour le glisser-déposer
   const handleDragStart = (e: React.DragEvent, card: Card) => {
@@ -96,7 +109,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
   // Rendu des emplacements de personnages
   const renderCharacterSlots = (characters: CardInstance[], isPlayer: boolean) => {
     const slots = [];
-    const maxSlots = 3; // Nombre d'emplacements de personnages
+    const maxSlots = maxCharacters; // Nombre d'emplacements de personnages
 
     for (let i = 0; i < maxSlots; i++) {
       const character = characters[i] || null;

--- a/src/services/PlayerBaseService.ts
+++ b/src/services/PlayerBaseService.ts
@@ -212,4 +212,24 @@ export class PlayerBaseImpl implements PlayerBase {
  */
 export const createPlayerBase = (config?: PlayerBaseConfig): PlayerBase => {
   return new PlayerBaseImpl(config);
-}; 
+};
+
+/**
+ * Crée une nouvelle instance de base de joueur en chargeant la configuration
+ * depuis `gameConfigService` pour déterminer les points de vie initiaux.
+ * Utilise la valeur par défaut (100) en cas d'erreur ou de configuration absente.
+ */
+export const createPlayerBaseFromConfig = async (): Promise<PlayerBase> => {
+  try {
+    const { gameConfigService } = await import('../utils/dataService');
+    const pv = await gameConfigService.getValue<number>('pv_base_initial');
+    const maxHealth = pv ?? 100;
+    return new PlayerBaseImpl({ maxHealth });
+  } catch (error) {
+    console.warn(
+      "Erreur lors du chargement de la configuration 'pv_base_initial':",
+      error
+    );
+    return new PlayerBaseImpl({ maxHealth: 100 });
+  }
+};

--- a/src/tests/PlayerBaseService.test.ts
+++ b/src/tests/PlayerBaseService.test.ts
@@ -4,8 +4,16 @@
  */
 
 import { createPlayerBase, PlayerBaseImpl } from '../services/PlayerBaseService';
+import { createPlayerBaseFromConfig } from '../services/PlayerBaseService';
 import { PlayerBase, PlayerBaseConfig } from '../types/player';
 import { Alteration } from '../types';
+
+// Mock de gameConfigService pour les tests liés à la configuration
+jest.mock('../utils/dataService', () => ({
+  gameConfigService: {
+    getValue: jest.fn()
+  }
+}));
 
 // Mock pour une altération de test
 const createMockAlteration = (id: number, stackable: boolean = false, duration: number | undefined = undefined): Alteration => {
@@ -186,4 +194,25 @@ describe('PlayerBaseService', () => {
     expect(playerBase.hasAlteration(1)).toBe(false);
     expect(playerBase.hasAlteration(3)).toBe(true);
   });
-}); 
+
+  describe('createPlayerBaseFromConfig', () => {
+    it('utilise la valeur de configuration lorsqu\'elle est disponible', async () => {
+      const { gameConfigService } = require('../utils/dataService');
+      gameConfigService.getValue.mockResolvedValue(150);
+
+      const base = await createPlayerBaseFromConfig();
+
+      expect(gameConfigService.getValue).toHaveBeenCalledWith('pv_base_initial');
+      expect(base.maxHealth).toBe(150);
+    });
+
+    it('retourne la valeur par defaut en cas d\'absence de configuration', async () => {
+      const { gameConfigService } = require('../utils/dataService');
+      gameConfigService.getValue.mockResolvedValue(null);
+
+      const base = await createPlayerBaseFromConfig();
+
+      expect(base.maxHealth).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
## Notes
- Ajout d'une méthode `createPlayerBaseFromConfig` qui charge les PV initiaux via `gameConfigService`
- Utilisation du paramètre `max_personnages` pour la zone de jeu
- Tests mis à jour pour valider la nouvelle fonctionnalité

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684774f65480832ba255695ccb28f807