### PR TITLE
Ajout indicateur de synergies actives

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -188,6 +188,13 @@ d'attaquer. Exemple dans `tagRules.json` :
 Le service gère la priorité d'application et permet de tester facilement de
 nouvelles synergies.
 
+## Visualisation des synergies
+
+Un composant `SynergyIndicator` affiche une icône sur chaque carte lorsqu'un
+effet de synergie est actif. Les informations détaillées sont accessibles via un
+tooltip et proviennent du `combatLogService`. Cette indication visuelle aide à
+comprendre rapidement quelles cartes profitent des combinaisons de tags.
+
 ## Interface de débug
 
 Une interface de débug (voir tâche 3) permet de modifier en temps réel les

--- a/public/TODO.md
+++ b/public/TODO.md
@@ -50,7 +50,7 @@
   - Ajouter des tooltips contextuels pour les nouvelles fonctionnalités
 - [ ] Ajouter des effets visuels pour les interactions importantes
   - [x] Animer les dégâts et soins sur la base
-  - [ ] Visualiser les synergies actives entre les cartes
+  - [x] Visualiser les synergies actives entre les cartes
 - [x] Créer un système de récompenses quotidiennes
   - Offrir du charisme et des objets bonus pour encourager la connexion régulière
   - Mettre en place des défis quotidiens avec des récompenses spéciales

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -4,6 +4,7 @@ import { Card, CardFrontend } from '../types/index';
 import { CardInstance } from '../types/combat';
 import { PlayerBase } from '../types/player';
 import PlayerBaseComponent from './PlayerBase';
+import SynergyIndicator from './SynergyIndicator';
 import { gameConfigService } from '../utils/dataService';
 
 interface GameBoardProps {
@@ -134,6 +135,9 @@ const GameBoard: React.FC<GameBoardProps> = ({
                   <span key={idx} className="tag">{tagInstance.tag.name}</span>
                 ))}
               </div>
+              <SynergyIndicator
+                effects={character.activeEffects.synergyEffect || []}
+              />
             </div>
           ) : (
             <div className="empty-slot-text">Emplacement personnage</div>

--- a/src/components/SynergyIndicator.css
+++ b/src/components/SynergyIndicator.css
@@ -1,0 +1,9 @@
+.synergy-indicator {
+  display: flex;
+  gap: 2px;
+  margin-top: 2px;
+}
+
+.synergy-icon {
+  color: #8e44ad;
+}

--- a/src/components/SynergyIndicator.tsx
+++ b/src/components/SynergyIndicator.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import LinkIcon from '@mui/icons-material/Link';
+import { Tooltip } from '@mui/material';
+import './SynergyIndicator.css';
+
+export interface SynergyEffect {
+  value: number;
+  source: string;
+  isPercentage: boolean;
+}
+
+interface SynergyIndicatorProps {
+  effects: SynergyEffect[];
+}
+
+const SynergyIndicator: React.FC<SynergyIndicatorProps> = ({ effects }) => {
+  if (!effects || effects.length === 0) return null;
+
+  return (
+    <div className="synergy-indicator">
+      {effects.map((e, idx) => (
+        <Tooltip
+          key={idx}
+          title={`${e.source} (+${e.value}${e.isPercentage ? '%' : ''})`}
+          arrow
+        >
+          <LinkIcon fontSize="small" className="synergy-icon" />
+        </Tooltip>
+      ))}
+    </div>
+  );
+};
+
+export default SynergyIndicator;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,3 +17,4 @@ export { default as Achievements } from './Achievements';
 export { default as DebugPanel } from './DebugPanel';
 export { default as SimulationPanel } from './SimulationPanel';
 export { default as ConflictSettingsPage } from './ConflictSettingsPage';
+export { default as SynergyIndicator } from './SynergyIndicator';

--- a/src/tests/ui/SynergyIndicator.test.tsx
+++ b/src/tests/ui/SynergyIndicator.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import SynergyIndicator, { SynergyEffect } from '../../components/SynergyIndicator';
+
+describe('SynergyIndicator', () => {
+  it('renders one icon per effect', () => {
+    const effects: SynergyEffect[] = [
+      { value: 5, source: 'Synergie: A avec B', isPercentage: true },
+      { value: 2, source: 'Synergie: C avec D', isPercentage: false },
+    ];
+    const { container } = render(<SynergyIndicator effects={effects} />);
+    expect(container.querySelectorAll('.synergy-icon').length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Notes
- Ajout d’un composant `SynergyIndicator` affichant les effets de synergie actifs sur chaque carte.
- Intégration du composant dans `GameBoard` et export depuis `index.ts`.
- Mise à jour de la documentation technique pour décrire la visualisation des synergies.
- Mise à jour du TODO pour marquer la tâche terminée.
- Ajout d’un test unitaire simple pour `SynergyIndicator`.

## Summary
- created `SynergyIndicator` component and styles
- displayed active synergies on character cards
- documented synergy visualization
- updated TODO progress
- added unit test for the indicator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480ec3dbbc832ba215546549496698