### PR TITLE
Add tooltips for debug and simulation panels

### DIFF
--- a/public/TODO.md
+++ b/public/TODO.md
@@ -47,7 +47,7 @@
 -## 🎮 Gameplay
 - [x] Implémenter un système de tutoriel interactif
   - [x] Créer des scénarios guidés pour expliquer les mécaniques de base
-  - [ ] Ajouter des tooltips contextuels pour les nouvelles fonctionnalités
+  - [x] Ajouter des tooltips contextuels pour les nouvelles fonctionnalités
 - [ ] Ajouter des effets visuels pour les interactions importantes
   - [x] Animer les dégâts et soins sur la base
   - [x] Visualiser les synergies actives entre les cartes

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { TextField, Button, Grid } from '@mui/material';
 import { gameConfigService } from '../utils/dataService';
+import { InfoTooltip } from './ui';
 
 interface ConfigValues {
   [key: string]: number;
@@ -12,6 +13,13 @@ const CONFIG_KEYS = [
   'budget_motivation_initial',
   'pv_base_initial'
 ];
+
+const TOOLTIPS: Record<string, string> = {
+  max_personnages: 'Nombre maximum de personnages simultanés sur le terrain',
+  emplacements_objet: "Nombre d'emplacements disponibles pour les objets",
+  budget_motivation_initial: 'Motivation de départ pour chaque joueur',
+  pv_base_initial: 'Points de vie initiaux de la base des joueurs'
+};
 
 const DebugPanel: React.FC = () => {
   const [values, setValues] = useState<ConfigValues>({});
@@ -58,13 +66,16 @@ const DebugPanel: React.FC = () => {
       <Grid container spacing={2}>
         {CONFIG_KEYS.map(key => (
           <Grid item xs={12} md={6} key={key}>
-            <TextField
-              fullWidth
-              label={key}
-              type="number"
-              value={inputs[key] ?? ''}
-              onChange={e => handleChange(key, Number(e.target.value))}
-            />
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              <TextField
+                fullWidth
+                label={key}
+                type="number"
+                value={inputs[key] ?? ''}
+                onChange={e => handleChange(key, Number(e.target.value))}
+              />
+              {TOOLTIPS[key] && <InfoTooltip title={TOOLTIPS[key]} />}
+            </div>
             <Button
               variant="contained"
               onClick={() => handleSubmit(key)}

--- a/src/components/SimulationPanel.tsx
+++ b/src/components/SimulationPanel.tsx
@@ -3,6 +3,7 @@ import { userService } from '../utils/userService';
 import { simulationResultsService } from '../utils/dataService';
 import { simulateGame } from '../simulation/gameSimulator';
 import type { Deck } from '../types/userTypes';
+import { InfoTooltip } from './ui';
 
 interface SimulationPanelProps {
   user: { id: string } | null;
@@ -19,6 +20,12 @@ const SimulationPanel: React.FC<SimulationPanelProps> = ({ user }) => {
     averageTurns: number;
     totalGames: number;
   } | null>(null);
+
+  const tooltips = {
+    deckA: 'Deck utilisé comme joueur principal',
+    deckB: 'Deck opposé pour la simulation',
+    runs: 'Nombre de parties à simuler'
+  } as const;
 
   useEffect(() => {
     const load = async () => {
@@ -53,7 +60,7 @@ const SimulationPanel: React.FC<SimulationPanelProps> = ({ user }) => {
       <h2>Simulations</h2>
       <div className="sim-form">
         <label>
-          Deck A
+          Deck A <InfoTooltip title={tooltips.deckA} />
           <select value={deckA} onChange={e => setDeckA(e.target.value)}>
             <option value="">Choisir un deck</option>
             {decks.map(d => (
@@ -62,7 +69,7 @@ const SimulationPanel: React.FC<SimulationPanelProps> = ({ user }) => {
           </select>
         </label>
         <label>
-          Deck B
+          Deck B <InfoTooltip title={tooltips.deckB} />
           <select value={deckB} onChange={e => setDeckB(e.target.value)}>
             <option value="">Choisir un deck</option>
             {decks.map(d => (
@@ -71,7 +78,7 @@ const SimulationPanel: React.FC<SimulationPanelProps> = ({ user }) => {
           </select>
         </label>
         <label>
-          Nombre de simulations
+          Nombre de simulations <InfoTooltip title={tooltips.runs} />
           <input type="number" min="1" value={runs} onChange={e => setRuns(parseInt(e.target.value, 10))} />
         </label>
         <button className="btn btn-primary" onClick={runSimulation}>Lancer</button>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,3 +19,4 @@ export { default as SimulationPanel } from './SimulationPanel';
 export { default as ConflictSettingsPage } from './ConflictSettingsPage';
 export { default as SynergyIndicator } from './SynergyIndicator';
 export { default as TutorialOverlay } from './TutorialOverlay';
+export { InfoTooltip } from './ui';

--- a/src/components/ui/InfoTooltip.css
+++ b/src/components/ui/InfoTooltip.css
@@ -1,0 +1,6 @@
+.info-tooltip-icon {
+  margin-left: 4px;
+  vertical-align: middle;
+  color: #555;
+  cursor: pointer;
+}

--- a/src/components/ui/InfoTooltip.tsx
+++ b/src/components/ui/InfoTooltip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Tooltip } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import './InfoTooltip.css';
+
+interface InfoTooltipProps {
+  title: string;
+}
+
+const InfoTooltip: React.FC<InfoTooltipProps> = ({ title }) => (
+  <Tooltip title={title} arrow>
+    <InfoOutlinedIcon className="info-tooltip-icon" fontSize="small" />
+  </Tooltip>
+);
+
+export default InfoTooltip;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,6 +5,7 @@ export { default as GameCard } from './GameCard';
 export { default as GameCardGrid } from './GameCardGrid';
 export { default as AdminPanel } from './AdminPanel';
 export { default as Notification } from './Notification';
+export { default as InfoTooltip } from './InfoTooltip';
 
 // Export du thème
-export { default as theme } from '../../theme/theme'; 
+export { default as theme } from '../../theme/theme';


### PR DESCRIPTION
## Summary
- provide `InfoTooltip` component in `ui` library
- add contextual help to DebugPanel inputs
- show tooltips in SimulationPanel form
- export new component and mark TODO as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848135b3fc0832b8b16ee8449174fc8