### PR TITLE
Implement crash recovery service

### DIFF
--- a/public/TODO.md
+++ b/public/TODO.md
@@ -59,9 +59,9 @@
 - [ ] Optimiser les performances du moteur de combat
   - Réduire la complexité des calculs de synergies
   - Mettre en cache les résultats des règles fréquemment utilisées
-- [ ] Améliorer la gestion des erreurs
+- [x] Améliorer la gestion des erreurs
   - [x] Ajouter des logs détaillés pour le débogage
-  - Implémenter un système de récupération après crash
+  - [x] Implémenter un système de récupération après crash
 - [ ] Mettre en place des tests de charge
   - Simuler des parties avec de nombreuses cartes et effets
   - Identifier et résoudre les goulots d'étranglement

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import authRouter from './auth';
 import session from 'express-session';
+import { ErrorRecoveryService } from '../services/errorRecoveryService';
 
 const app = express();
 const port = process.env.SERVER_PORT || 3000;
@@ -28,6 +29,10 @@ app.use(session({
 // Routes d'authentification
 app.use('/api/auth', authRouter);
 
+ErrorRecoveryService.init(() => {
+  console.error("Redemarrage du serveur suite a une erreur critique");
+  process.exit(1);
+});
 // Démarrage du serveur
 app.listen(port, () => {
   console.log(`Serveur démarré sur le port ${port}`);

--- a/src/services/errorRecoveryService.ts
+++ b/src/services/errorRecoveryService.ts
@@ -1,0 +1,44 @@
+import { debugLogsService } from '../utils/dataService';
+import { logger } from '../utils/logger';
+
+/**
+ * Service de récupération après crash.
+ * Il capture les erreurs non interceptées et les promesses rejetées
+ * afin de consigner les informations dans la base de logs puis
+ * d'exécuter une fonction de récupération optionnelle.
+ */
+export class ErrorRecoveryService {
+  static init(restartCallback?: () => void): void {
+    process.on('uncaughtException', error => {
+      this.handleError(error, restartCallback);
+    });
+
+    process.on('unhandledRejection', reason => {
+      const error = reason instanceof Error ? reason : new Error(String(reason));
+      this.handleError(error, restartCallback);
+    });
+  }
+
+  private static async handleError(error: Error, restartCallback?: () => void) {
+    logger.error('Unhandled error caught by ErrorRecoveryService', error);
+    try {
+      await debugLogsService.create({
+        log_type: 'error',
+        severity: 'critical',
+        message: error.message,
+        context: {},
+        stack_trace: error.stack
+      });
+    } catch (logErr) {
+      logger.error('Failed to persist error log', logErr);
+    } finally {
+      if (restartCallback) {
+        try {
+          restartCallback();
+        } catch (callbackErr) {
+          logger.error('Error while executing recovery callback', callbackErr);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ErrorRecoveryService` to log and recover from crashes
- enable the recovery service in the server
- mark the TODO task as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848183e61f8832ba66608677a240ce8