### PR TITLE
Add glow effect to synergy indicators

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -194,6 +194,8 @@ Un composant `SynergyIndicator` affiche une icône sur chaque carte lorsqu'un
 effet de synergie est actif. Les informations détaillées sont accessibles via un
 tooltip et proviennent du `combatLogService`. Cette indication visuelle aide à
 comprendre rapidement quelles cartes profitent des combinaisons de tags.
+Depuis la version actuelle, l'icône s'accompagne d'un effet de halo
+(`glowPulse`) afin de mettre en valeur ces interactions importantes.
 
 ## Interface de débug
 

--- a/public/TODO.md
+++ b/public/TODO.md
@@ -48,7 +48,7 @@
 - [x] Implémenter un système de tutoriel interactif
   - [x] Créer des scénarios guidés pour expliquer les mécaniques de base
   - [x] Ajouter des tooltips contextuels pour les nouvelles fonctionnalités
-- [ ] Ajouter des effets visuels pour les interactions importantes
+- [x] Ajouter des effets visuels pour les interactions importantes
   - [x] Animer les dégâts et soins sur la base
   - [x] Visualiser les synergies actives entre les cartes
 - [x] Créer un système de récompenses quotidiennes

--- a/src/components/SynergyIndicator.css
+++ b/src/components/SynergyIndicator.css
@@ -7,3 +7,7 @@
 .synergy-icon {
   color: #8e44ad;
 }
+
+.synergy-icon.glow-pulse {
+  animation: glowPulse 2s infinite;
+}

--- a/src/components/SynergyIndicator.tsx
+++ b/src/components/SynergyIndicator.tsx
@@ -24,7 +24,7 @@ const SynergyIndicator: React.FC<SynergyIndicatorProps> = ({ effects }) => {
           title={`${e.source} (+${e.value}${e.isPercentage ? '%' : ''})`}
           arrow
         >
-          <LinkIcon fontSize="small" className="synergy-icon" />
+          <LinkIcon fontSize="small" className="synergy-icon glow-pulse" />
         </Tooltip>
       ))}
     </div>

--- a/src/tests/ui/SynergyIndicator.test.tsx
+++ b/src/tests/ui/SynergyIndicator.test.tsx
@@ -10,6 +10,10 @@ describe('SynergyIndicator', () => {
       { value: 2, source: 'Synergie: C avec D', isPercentage: false },
     ];
     const { container } = render(<SynergyIndicator effects={effects} />);
-    expect(container.querySelectorAll('.synergy-icon').length).toBe(2);
+    const icons = container.querySelectorAll('.synergy-icon');
+    expect(icons.length).toBe(2);
+    icons.forEach(icon => {
+      expect(icon.classList.contains('glow-pulse')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- animate synergy icon with global glowPulse animation
- document this visual effect in the technical guide
- mark TODO item about visual effects complete
- test that synergy icons carry the new class

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68482287f840832bb211aaf14bd40558