### PR TITLE
Add booster debug buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,7 +603,7 @@ const AppContent: React.FC = () => {
         <Route path="/debug" element={
           user?.is_admin ? (
             <AdminPanel title="Debug" icon="🛠">
-              <DebugPanel />
+              <DebugPanel user={user as User} />
             </AdminPanel>
           ) : (
             <Navigate to="/" replace />

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { TextField, Button, Grid } from '@mui/material';
 import { gameConfigService } from '../utils/dataService';
+import { boosterService } from '../utils/boosterService';
 import { InfoTooltip } from './ui';
+
+interface DebugPanelProps {
+  user: { id: string };
+}
 
 interface ConfigValues {
   [key: string]: number;
@@ -21,9 +26,11 @@ const TOOLTIPS: Record<string, string> = {
   pv_base_initial: 'Points de vie initiaux de la base des joueurs'
 };
 
-const DebugPanel: React.FC = () => {
+const DebugPanel: React.FC<DebugPanelProps> = ({ user }) => {
   const [values, setValues] = useState<ConfigValues>({});
   const [inputs, setInputs] = useState<ConfigValues>({});
+  const [isGranting, setIsGranting] = useState(false);
+  const [isOpening, setIsOpening] = useState(false);
 
   const loadConfigs = async () => {
     try {
@@ -60,6 +67,28 @@ const DebugPanel: React.FC = () => {
     }
   };
 
+  const handleGrantBooster = async () => {
+    try {
+      setIsGranting(true);
+      await boosterService.grantBooster(user.id);
+    } catch (error) {
+      console.error('Erreur lors de la distribution du booster:', error);
+    } finally {
+      setIsGranting(false);
+    }
+  };
+
+  const handleOpenBooster = async () => {
+    try {
+      setIsOpening(true);
+      await boosterService.openBooster();
+    } catch (error) {
+      console.error("Erreur lors de l'ouverture du booster:", error);
+    } finally {
+      setIsOpening(false);
+    }
+  };
+
   return (
     <div className="debug-panel">
       <h2>Configuration du jeu</h2>
@@ -87,6 +116,25 @@ const DebugPanel: React.FC = () => {
           </Grid>
         ))}
       </Grid>
+
+      <div style={{ marginTop: '2rem' }}>
+        <h2>Boosters</h2>
+        <Button
+          variant="contained"
+          onClick={handleGrantBooster}
+          disabled={isGranting}
+          sx={{ mr: 1 }}
+        >
+          Obtenir un booster
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={handleOpenBooster}
+          disabled={isOpening}
+        >
+          Ouvrir un booster
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/utils/boosterService.ts
+++ b/src/utils/boosterService.ts
@@ -1,0 +1,27 @@
+export const boosterService = {
+  async grantBooster(userId: string, boosterType = 'standard_booster', quantity = 1) {
+    const response = await fetch(`/api/users/${userId}/grant-booster`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ booster_type: boosterType, quantity })
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Grant booster failed: ${response.status} ${text}`);
+    }
+    return response.json();
+  },
+
+  async openBooster(boosterType = 'standard_booster') {
+    const response = await fetch('/api/me/open-booster', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ booster_type: boosterType })
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Open booster failed: ${response.status} ${text}`);
+    }
+    return response.json();
+  }
+};


### PR DESCRIPTION
## Summary
- allow DebugPanel to grant and open boosters via API
- pass user info to DebugPanel
- add boosterService for API calls

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852efdd2db0832bbd1fc434d6a6079c