### PR TITLE
Add booster opening component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Objectives from './components/Objectives';
 import TodoProgress from './components/TodoProgress';
 import Achievements from './components/Achievements';
 import InventoryPage from './components/InventoryPage';
+import BoosterOpening from './components/BoosterOpening';
 import { supabase } from './utils/supabaseClient';
 
 // Import de nos nouveaux composants UI
@@ -562,6 +563,15 @@ const AppContent: React.FC = () => {
         {/* Éditeur de booster */}
         <Route path="/boosters" element={
           <BoosterForm booster={boosterData} onSave={() => {}} />
+        } />
+
+        {/* Ouverture de booster */}
+        <Route path="/open-booster" element={
+          user ? (
+            <BoosterOpening />
+          ) : (
+            <Navigate to="/login" replace />
+          )
         } />
         
         {/* Gestionnaire d'altérations */}

--- a/src/components/BoosterOpening.css
+++ b/src/components/BoosterOpening.css
@@ -1,0 +1,18 @@
+.booster-opening {
+  text-align: center;
+}
+
+.open-btn {
+  margin-bottom: 1rem;
+}
+
+.opened-cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.opened-card {
+  opacity: 0;
+}

--- a/src/components/BoosterOpening.tsx
+++ b/src/components/BoosterOpening.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import CardPreview from './CardPreview';
+import { boosterService } from '../utils/boosterService';
+import { supabase } from '../utils/supabaseClient';
+import type { Card } from '../types';
+import './BoosterOpening.css';
+
+interface BoosterOpeningProps {
+  boosterType?: string;
+}
+
+const BoosterOpening: React.FC<BoosterOpeningProps> = ({ boosterType = 'standard_booster' }) => {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [isOpening, setIsOpening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const openBooster = async () => {
+    try {
+      setIsOpening(true);
+      setError(null);
+      const result = await boosterService.openBooster(boosterType);
+      if (result.cards && result.cards.length > 0) {
+        const ids = result.cards.map((c: any) => c.id);
+        const { data, error: fetchError } = await supabase
+          .from('cards')
+          .select('*')
+          .in('id', ids);
+        if (fetchError) throw fetchError;
+        setCards(data as Card[]);
+      }
+    } catch (err: any) {
+      console.error('Erreur ouverture booster:', err);
+      setError(err.message || 'Erreur inconnue');
+    } finally {
+      setIsOpening(false);
+    }
+  };
+
+  return (
+    <div className="booster-opening">
+      <button onClick={openBooster} disabled={isOpening} className="open-btn">
+        {isOpening ? 'Ouverture...' : 'Ouvrir un booster'}
+      </button>
+      {error && <div className="error-msg">{error}</div>}
+      <div className="opened-cards">
+        {cards.map((card, index) => (
+          <div
+            key={card.id}
+            className="opened-card slide-in-up"
+            style={{ animationDelay: `${index * 0.2}s` }}
+          >
+            <CardPreview card={card} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BoosterOpening;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,4 +18,5 @@ export { default as SimulationPanel } from './SimulationPanel';
 export { default as ConflictSettingsPage } from './ConflictSettingsPage';
 export { default as SynergyIndicator } from './SynergyIndicator';
 export { default as TutorialOverlay } from './TutorialOverlay';
+export { default as BoosterOpening } from './BoosterOpening';
 export { InfoTooltip } from './ui';

--- a/src/components/ui/GameNav.tsx
+++ b/src/components/ui/GameNav.tsx
@@ -63,12 +63,20 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             Cartes
           </Link>
           
-          <Link 
-            to="/boosters" 
+          <Link
+            to="/boosters"
             onClick={closeMobileMenu}
             className={`nav-link ${isActive('/boosters') ? 'active' : ''}`}
           >
             Boosters
+          </Link>
+
+          <Link
+            to="/open-booster"
+            onClick={closeMobileMenu}
+            className={`nav-link ${isActive('/open-booster') ? 'active' : ''}`}
+          >
+            Ouvrir Booster
           </Link>
           
           <Link 
@@ -183,12 +191,20 @@ const GameNav: React.FC<GameNavProps> = ({ user, isAdmin = false, onLogout }) =>
             Cartes
           </Link>
           
-          <Link 
-            to="/boosters" 
+          <Link
+            to="/boosters"
             onClick={closeMobileMenu}
             className={`mobile-nav-link ${isActive('/boosters') ? 'active' : ''}`}
           >
             Boosters
+          </Link>
+
+          <Link
+            to="/open-booster"
+            onClick={closeMobileMenu}
+            className={`mobile-nav-link ${isActive('/open-booster') ? 'active' : ''}`}
+          >
+            Ouvrir Booster
           </Link>
           
           <Link 


### PR DESCRIPTION
## Summary
- create `BoosterOpening` component to open booster packs
- add menu link and route to display booster opening page
- export component from index

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852f17aa4d8832b9c2114629ff9f5f3