### PR TITLE
Add responsive turn tracker panel

### DIFF
--- a/src/components/TurnTracker.css
+++ b/src/components/TurnTracker.css
@@ -1,0 +1,63 @@
+.turn-tracker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #2c3e50;
+  color: #ecf0f1;
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  gap: 10px;
+}
+
+.turn-info {
+  flex: 1 1 150px;
+}
+
+.turn-number,
+.phase,
+.active-player {
+  margin-bottom: 4px;
+}
+
+.turn-buttons button {
+  margin-right: 5px;
+}
+
+.resources {
+  flex: 1 1 150px;
+  text-align: center;
+}
+
+.actions {
+  flex: 2 1 200px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 5px;
+}
+
+.action-button {
+  padding: 6px 10px;
+  border: none;
+  border-radius: 4px;
+  background-color: #34495e;
+  color: #ecf0f1;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.action-button:hover {
+  background-color: #3e5d77;
+}
+
+@media (max-width: 600px) {
+  .turn-tracker {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .actions {
+    justify-content: flex-start;
+  }
+}

--- a/src/components/TurnTracker.tsx
+++ b/src/components/TurnTracker.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { GameState, Player } from '../types';
+import { getModifiedMaxCharisme } from '../utils/charismeService';
+import './TurnTracker.css';
+
+export interface TurnAction {
+  id: string;
+  label: string;
+  onClick: () => void;
+}
+
+interface TurnTrackerProps {
+  gameState: GameState;
+  actions: TurnAction[];
+  onNextPhase?: () => void;
+  onNextTurn?: () => void;
+}
+
+const TurnTracker: React.FC<TurnTrackerProps> = ({
+  gameState,
+  actions,
+  onNextPhase,
+  onNextTurn
+}) => {
+  const activePlayer: Player = gameState.players[gameState.activePlayer];
+
+  return (
+    <div className="turn-tracker">
+      <div className="turn-info">
+        <div className="turn-number">Tour {gameState.turnCount}</div>
+        <div className="phase">Phase : {gameState.phase}</div>
+        <div className="active-player">Joueur actif : {activePlayer.name}</div>
+        <div className="turn-buttons">
+          {onNextPhase && (
+            <button onClick={onNextPhase}>Phase suivante</button>
+          )}
+          {onNextTurn && (
+            <button onClick={onNextTurn}>Fin de tour</button>
+          )}
+        </div>
+      </div>
+
+      <div className="resources">
+        <div className="resource motivation">
+          Motivation : {activePlayer.motivation} / {activePlayer.baseMotivation}
+        </div>
+        <div className="resource charisme">
+          Charisme : {activePlayer.charisme ?? 0} / {getModifiedMaxCharisme(activePlayer)}
+        </div>
+      </div>
+
+      <div className="actions">
+        {actions.map(action => (
+          <button
+            key={action.id}
+            onClick={action.onClick}
+            className="action-button"
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TurnTracker;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,4 +19,5 @@ export { default as ConflictSettingsPage } from './ConflictSettingsPage';
 export { default as SynergyIndicator } from './SynergyIndicator';
 export { default as TutorialOverlay } from './TutorialOverlay';
 export { default as BoosterOpening } from './BoosterOpening';
+export { default as TurnTracker } from './TurnTracker';
 export { InfoTooltip } from './ui';


### PR DESCRIPTION
## Summary
- display game turn & phase information
- show current player's motivation and charisme values
- list action buttons and include next phase/turn controls
- export new `TurnTracker` component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f3207e60832b94258f4f34bc25ae