### PR TITLE
Implement draggable hand and display card stats

### DIFF
--- a/src/components/GameBoard.css
+++ b/src/components/GameBoard.css
@@ -189,6 +189,18 @@
   font-weight: bold;
 }
 
+.card-stats {
+  display: flex;
+  justify-content: space-around;
+  font-size: 0.8rem;
+  margin-top: 4px;
+}
+
+.card-attack,
+.card-defense {
+  color: #ecf0f1;
+}
+
 .card-tags {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -5,6 +5,7 @@ import { CardInstance } from '../types/combat';
 import { PlayerBase } from '../types/player';
 import PlayerBaseComponent from './PlayerBase';
 import SynergyIndicator from './SynergyIndicator';
+import Hand from './Hand';
 import { gameConfigService } from '../utils/dataService';
 
 interface GameBoardProps {
@@ -123,12 +124,16 @@ const GameBoard: React.FC<GameBoardProps> = ({
           onDrop={(e) => handleDrop(e, isPlayer ? 'player-character' : 'opponent-character', i)}
         >
           {character ? (
-            <div 
+            <div
               className="character-card"
               onClick={() => handleCardClick(character, isPlayer ? 'player-character' : 'opponent-character')}
             >
               <div className="card-name">{character.cardDefinition.name}</div>
               <div className="card-health">❤️ {character.currentHealth}/{character.maxHealth}</div>
+              <div className="card-stats">
+                <span className="card-attack">⚔️ {character.temporaryStats.attack}</span>
+                <span className="card-defense">🛡️ {character.temporaryStats.defense}</span>
+              </div>
               {/* Afficher les tags actifs */}
               <div className="card-tags">
                 {character.activeTags.map((tagInstance, idx) => (
@@ -179,51 +184,6 @@ const GameBoard: React.FC<GameBoardProps> = ({
     }
 
     return slots;
-  };
-
-  // Rendu de la main du joueur avec gestion spéciale des cartes événement
-  const renderPlayerHand = () => {
-    return (
-      <div className="player-hand-container">
-        <div className="section-title">Votre Main</div>
-        <div className="player-hand">
-          {playerHand.length > 0 ? (
-            playerHand.map((card) => (
-              <div 
-                key={`hand-card-${card.id}`}
-                className={`hand-card hand-card-${card.type} ${card.type === 'evenement' ? 'face-down' : ''}`}
-                draggable
-                onDragStart={(e) => handleDragStart(e, card)}
-                onClick={() => handleCardClick(card, 'player-hand')}
-              >
-                {card.type !== 'evenement' ? (
-                  <>
-                    <div className="card-name">{card.name}</div>
-                    <div className="card-type">{card.type}</div>
-                    {card.type === 'personnage' && card.properties && card.properties.health && (
-                      <div className="card-health">❤️ {card.properties.health}</div>
-                    )}
-                    {card.rarity && (
-                      <div className="card-rarity">{card.rarity}</div>
-                    )}
-                    {card.type === 'action' && (
-                      <div className="action-indicator">Activable partout</div>
-                    )}
-                  </>
-                ) : (
-                  <div className="event-card-back">Événement</div>
-                )}
-              </div>
-            ))
-          ) : (
-            <div className="empty-hand-message">
-              <span>Aucune carte en main</span>
-              <div className="hand-hint">Utilisez le bouton "Piocher une carte" ci-dessous</div>
-            </div>
-          )}
-        </div>
-      </div>
-    );
   };
 
   // Rendu de la main de l'adversaire (faces cachées)
@@ -327,7 +287,11 @@ const GameBoard: React.FC<GameBoardProps> = ({
 
       {/* Zone de la main du joueur mise en évidence, séparée du reste */}
       <div className="main-player-hand-area">
-        {renderPlayerHand()}
+        <Hand
+          cards={playerHand}
+          onDragStart={handleDragStart}
+          onCardClick={(card) => handleCardClick(card, 'player-hand')}
+        />
       </div>
     </div>
   );

--- a/src/components/Hand.tsx
+++ b/src/components/Hand.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Card } from '../types';
+
+interface HandProps {
+  cards: Card[];
+  onDragStart: (e: React.DragEvent, card: Card) => void;
+  onCardClick?: (card: Card) => void;
+}
+
+const Hand: React.FC<HandProps> = ({ cards, onDragStart, onCardClick }) => {
+  return (
+    <div className="player-hand-container">
+      <div className="section-title">Votre Main</div>
+      <div className="player-hand">
+        {cards.length > 0 ? (
+          cards.map(card => (
+            <div
+              key={`hand-card-${card.id}`}
+              className={`hand-card hand-card-${card.type} ${card.type === 'evenement' ? 'face-down' : ''}`}
+              draggable
+              onDragStart={e => onDragStart(e, card)}
+              onClick={() => onCardClick && onCardClick(card)}
+            >
+              {card.type !== 'evenement' ? (
+                <>
+                  <div className="card-name">{card.name}</div>
+                  <div className="card-type">{card.type}</div>
+                  {card.type === 'personnage' && card.properties && card.properties.health && (
+                    <div className="card-health">❤️ {card.properties.health}</div>
+                  )}
+                  {card.rarity && (
+                    <div className="card-rarity">{card.rarity}</div>
+                  )}
+                  {card.type === 'action' && (
+                    <div className="action-indicator">Activable partout</div>
+                  )}
+                </>
+              ) : (
+                <div className="event-card-back">Événement</div>
+              )}
+            </div>
+          ))
+        ) : (
+          <div className="empty-hand-message">
+            <span>Aucune carte en main</span>
+            <div className="hand-hint">Utilisez le bouton \"Piocher une carte\" ci-dessous</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Hand;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ export { default as Help } from './Help';
 export { default as UserManager } from './UserManager';
 export { default as TodoProgress } from './TodoProgress';
 export { default as GameBoard } from './GameBoard';
+export { default as Hand } from './Hand';
 export { default as GameBoardTest } from './GameBoardTest';
 export { default as PlayerBase } from './PlayerBase';
 export { default as ConflictResolutionManager } from './ConflictResolutionManager';


### PR DESCRIPTION
## Summary
- create `Hand` component with drag & drop
- show attack/defense stats for characters on the board
- integrate new Hand component in `GameBoard`
- style card stats display

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852f6414158832bb3141f4341522c48