### PR TITLE
Add motivation bar UI

### DIFF
--- a/public/TODO.md
+++ b/public/TODO.md
@@ -25,7 +25,7 @@
   - Drag & drop pour jouer les cartes
   - Emplacements visuels pour personnages et objets
   - Affichage des statistiques des cartes en jeu
-- [ ] **Système de motivation** avec interface
+- [x] **Système de motivation** avec interface
   - Barre de motivation visible et interactive
   - Coût des actions affiché clairement
   - Renouvellement automatique à chaque tour

--- a/src/components/GameBoardTest.tsx
+++ b/src/components/GameBoardTest.tsx
@@ -261,10 +261,15 @@ const GameBoardTest: React.FC = () => {
   const Content: React.FC = () => {
     const { state, nextPhase, nextTurn } = useGameEngine();
 
+    const turnActions = [
+      { id: 'attack', label: 'Attaquer', cost: 2, onClick: () => console.log('Attaque') },
+      { id: 'draw', label: 'Piocher', cost: 1, onClick: () => console.log('Piocher') }
+    ];
+
     return (
       <div className="game-board-test-container">
         <h1>Test de la Zone de Jeu</h1>
-        <TurnTracker gameState={state} actions={[]} onNextPhase={nextPhase} onNextTurn={nextTurn} />
+        <TurnTracker gameState={state} actions={turnActions} onNextPhase={nextPhase} onNextTurn={nextTurn} />
         <div className="game-board-container">
           <GameBoard
             playerHand={playerHand}

--- a/src/components/MotivationDisplay.css
+++ b/src/components/MotivationDisplay.css
@@ -6,6 +6,7 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   min-width: 200px;
   transition: all 0.3s ease;
+  cursor: pointer;
 }
 
 .motivation-display.active {

--- a/src/components/MotivationDisplay.tsx
+++ b/src/components/MotivationDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Player, MotivationModifier } from '../types/index';
 import './MotivationDisplay.css';
 
@@ -13,10 +13,13 @@ interface MotivationDisplayProps {
  * Ce composant montre la quantité de motivation disponible pour un joueur,
  * ainsi que les modificateurs actifs si demandé.
  */
-const MotivationDisplay: React.FC<MotivationDisplayProps> = ({ 
-  player, 
-  isActive = false 
+const MotivationDisplay: React.FC<MotivationDisplayProps> = ({
+  player,
+  isActive = false
 }) => {
+  const [showDetails, setShowDetails] = useState(false);
+
+  const toggleDetails = () => setShowDetails(prev => !prev);
   // Calculer le pourcentage de remplissage de la barre
   const getBaseMotivation = (): number => {
     return player.baseMotivation || 10; // Valeur par défaut si non définie
@@ -58,7 +61,10 @@ const MotivationDisplay: React.FC<MotivationDisplayProps> = ({
   };
   
   return (
-    <div className={`motivation-display ${isActive ? 'active' : ''}`}>
+    <div
+      className={`motivation-display ${isActive ? 'active' : ''}`}
+      onClick={toggleDetails}
+    >
       <div className="motivation-header">
         <h3>Motivation</h3>
         <div className="motivation-value">
@@ -76,7 +82,7 @@ const MotivationDisplay: React.FC<MotivationDisplayProps> = ({
         ></div>
       </div>
       
-      {isActive && renderModifiers()}
+      {(isActive || showDetails) && renderModifiers()}
     </div>
   );
 };

--- a/src/components/TurnTracker.tsx
+++ b/src/components/TurnTracker.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import type { GameState, Player } from '../types';
+import MotivationDisplay from './MotivationDisplay';
 import { getModifiedMaxCharisme } from '../utils/charismeService';
 import './TurnTracker.css';
 
 export interface TurnAction {
   id: string;
   label: string;
+  cost: number;
   onClick: () => void;
 }
 
@@ -43,9 +45,7 @@ const TurnTracker: React.FC<TurnTrackerProps> = ({
       </div>
 
       <div className="resources">
-        <div className="resource motivation">
-          Motivation : {activePlayer.motivation} / {activePlayer.baseMotivation}
-        </div>
+        <MotivationDisplay player={activePlayer} isActive />
         <div className="resource charisme">
           Charisme : {activePlayer.charisme ?? 0} / {getModifiedMaxCharisme(activePlayer)}
         </div>
@@ -57,8 +57,9 @@ const TurnTracker: React.FC<TurnTrackerProps> = ({
             key={action.id}
             onClick={action.onClick}
             className="action-button"
+            title={`Coût : ${action.cost}`}
           >
-            {action.label}
+            {action.label} ({action.cost})
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add motivation bar toggle details
- make bar clickable
- show action costs in TurnTracker
- wire up sample actions in game board test
- mark motivation system todo as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f8557158832bac8ae37a2d37b8d3