### PR TITLE
Implement synergy preview and combat log

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -196,6 +196,16 @@ tooltip et proviennent du `combatLogService`. Cette indication visuelle aide à
 comprendre rapidement quelles cartes profitent des combinaisons de tags.
 Depuis la version actuelle, l'icône s'accompagne d'un effet de halo
 (`glowPulse`) afin de mettre en valeur ces interactions importantes.
+Les synergies sont signalées non seulement sur les personnages mais
+aussi sur les objets équipés et la carte de lieu active.
+Lors du survol d'une cible dans `TargetSelector`, un `SynergyIndicator`
+affiche une prévisualisation des effets appliqués avant de confirmer
+l'action.
+
+Toutes les interactions déclenchées pendant le combat sont enregistrées
+par `combatLogService`. Les événements sont consultables via le
+composant `CombatLogViewer` qui affiche un historique et des
+notifications.
 
 ## Interface de débug
 

--- a/src/components/CombatLogViewer.tsx
+++ b/src/components/CombatLogViewer.tsx
@@ -45,7 +45,7 @@ const CombatLogViewer: React.FC = () => {
       <ul>
         {events.map((e, idx) => (
           <li key={idx}>
-            <Tooltip title={e.result.effectDescription} arrow>
+            <Tooltip title={e.result?.effectDescription || ''} arrow>
               <span>{e.message}</span>
             </Tooltip>
           </li>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -170,11 +170,14 @@ const GameBoard: React.FC<GameBoardProps> = ({
           onDrop={(e) => handleDrop(e, isPlayer ? 'player-object' : 'opponent-object', i)}
         >
           {object ? (
-            <div 
+            <div
               className="object-card"
               onClick={() => handleCardClick(object, isPlayer ? 'player-object' : 'opponent-object')}
             >
               <div className="card-name">{object.cardDefinition.name}</div>
+              <SynergyIndicator
+                effects={object.activeEffects.synergyEffect || []}
+              />
             </div>
           ) : (
             <div className="empty-slot-text">Emplacement objet</div>
@@ -226,12 +229,15 @@ const GameBoard: React.FC<GameBoardProps> = ({
     return (
       <div className="active-lieu">
         {activeLieu ? (
-          <div 
+          <div
             className="lieu-card"
             onClick={() => handleCardClick(activeLieu, 'active-lieu')}
           >
             <div className="card-name">{activeLieu.cardDefinition.name}</div>
             <div className="card-description">{activeLieu.cardDefinition.description}</div>
+            <SynergyIndicator
+              effects={activeLieu.activeEffects.synergyEffect || []}
+            />
           </div>
         ) : (
           <div className="empty-lieu">Aucun lieu actif</div>

--- a/src/components/TargetSelector.tsx
+++ b/src/components/TargetSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './TargetSelector.css';
 import { CardInstance, ManualTargetingOptions } from '../types/combat';
+import SynergyIndicator from './SynergyIndicator';
 
 interface TargetSelectorProps extends ManualTargetingOptions {
   isOpen: boolean;
@@ -24,6 +25,7 @@ const TargetSelector: React.FC<TargetSelectorProps> = ({
 }) => {
   const [selectedTargets, setSelectedTargets] = useState<CardInstance[]>([]);
   const [filteredTargets, setFilteredTargets] = useState<CardInstance[]>(possibleTargets);
+  const [hoveredTarget, setHoveredTarget] = useState<CardInstance | null>(null);
 
   // Reset selection when component opens
   useEffect(() => {
@@ -120,10 +122,12 @@ const TargetSelector: React.FC<TargetSelectorProps> = ({
             <p className="no-targets">Aucune cible disponible correspondant aux critères</p>
           ) : (
             filteredTargets.map(target => (
-              <div 
+              <div
                 key={target.instanceId}
                 className={`target-card ${selectedTargets.some(t => t.instanceId === target.instanceId) ? 'selected' : ''}`}
                 onClick={() => handleTargetClick(target)}
+                onMouseEnter={() => setHoveredTarget(target)}
+                onMouseLeave={() => setHoveredTarget(null)}
               >
                 <div className="target-header">
                   <h4>{target.cardDefinition.name}</h4>
@@ -141,6 +145,9 @@ const TargetSelector: React.FC<TargetSelectorProps> = ({
                       <span key={index} className="tag">{tagInstance.tag.name}</span>
                     ))}
                   </div>
+                )}
+                {hoveredTarget?.instanceId === target.instanceId && (
+                  <SynergyIndicator effects={target.activeEffects.synergyEffect || []} />
                 )}
               </div>
             ))

--- a/src/services/__tests__/combatLogService.test.ts
+++ b/src/services/__tests__/combatLogService.test.ts
@@ -32,6 +32,7 @@ describe('combatLogService', () => {
     const event = listener.mock.calls[0][0];
     expect(event.result).toBe(sampleResult);
     expect(event.targetCardId).toBe('card1');
+    expect(event.type).toBe('tag');
     combatLogService.off(listener);
   });
 
@@ -53,5 +54,16 @@ describe('combatLogService', () => {
 
     combatLogService.logTagRule(sampleResult, target);
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('logInteraction should emit interaction events', () => {
+    const listener = jest.fn();
+    combatLogService.on(listener);
+    combatLogService.logInteraction('Test interaction');
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0][0];
+    expect(event.type).toBe('interaction');
+    expect(event.message).toBe('Test interaction');
+    combatLogService.off(listener);
   });
 });

--- a/src/services/combatLogService.ts
+++ b/src/services/combatLogService.ts
@@ -3,9 +3,10 @@ import { CardInstance } from '../types/combat';
 
 export interface CombatLogEvent {
   message: string;
-  result: TagRuleApplicationResult;
-  targetCardId: string;
   timestamp: number;
+  type: 'tag' | 'interaction';
+  result?: TagRuleApplicationResult;
+  targetCardId?: string;
 }
 
 type Listener = (event: CombatLogEvent) => void;
@@ -35,7 +36,17 @@ class CombatLogService {
 
   logTagRule(result: TagRuleApplicationResult, target: CardInstance) {
     const message = `Tag '${result.sourceTag}' \u2192 ${result.effectDescription}`;
-    this.emit({ message, result, targetCardId: target.instanceId, timestamp: Date.now() });
+    this.emit({
+      message,
+      result,
+      targetCardId: target.instanceId,
+      timestamp: Date.now(),
+      type: 'tag'
+    });
+  }
+
+  logInteraction(message: string) {
+    this.emit({ message, timestamp: Date.now(), type: 'interaction' });
   }
 
   setEnabled(enabled: boolean) {


### PR DESCRIPTION
## Summary
- show `SynergyIndicator` on object and lieu cards
- preview synergy effects on target hover
- enhance combat logging with generic interaction events
- adjust `CombatLogViewer` for optional details
- document synergy visualisation and logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532c584f4c832ba74d9f4dfb77837f