### PR TITLE
Add active alteration display

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -197,6 +197,14 @@ comprendre rapidement quelles cartes profitent des combinaisons de tags.
 Depuis la version actuelle, l'icône s'accompagne d'un effet de halo
 (`glowPulse`) afin de mettre en valeur ces interactions importantes.
 
+## Altérations actives
+
+Un composant `ActiveAlterations` complète cette visualisation en affichant les
+buffs et debuffs présents sur chaque personnage. Les altérations sont
+représentées par une icône colorée accompagnée de la durée restante et du
+nombre de cumuls. Lorsqu'une altération expire (gérée par `resetForNextTurn`),
+le badge disparaît automatiquement de la carte.
+
 ## Interface de débug
 
 Une interface de débug (voir tâche 3) permet de modifier en temps réel les

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -82,6 +82,10 @@ Lors de l'exécution, un des sous-effets est sélectionné selon son poids.
    - Icône
    - Couleur
 
+Une fois en jeu, les altérations actives apparaissent sur chaque personnage
+grâce au composant `ActiveAlterations`. Les icônes indiquent la nature du buff
+ou du debuff, la durée restante et le nombre de cumuls éventuels.
+
 ### 5. Création de Boosters
 
 #### Création d'un Booster

--- a/src/components/ActiveAlterations.css
+++ b/src/components/ActiveAlterations.css
@@ -1,0 +1,48 @@
+.active-alterations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin-top: 2px;
+}
+
+.alteration-badge {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+
+.alteration-badge.buff {
+  background-color: #2ecc71;
+}
+
+.alteration-badge.debuff {
+  background-color: #e74c3c;
+}
+
+.alteration-badge.status {
+  background-color: #3498db;
+}
+
+.alteration-badge.other {
+  background-color: #95a5a6;
+}
+
+.badge-stack {
+  position: absolute;
+  bottom: -6px;
+  right: -3px;
+  font-size: 0.55rem;
+}
+
+.badge-duration {
+  position: absolute;
+  top: -6px;
+  right: -3px;
+  font-size: 0.55rem;
+}

--- a/src/components/ActiveAlterations.tsx
+++ b/src/components/ActiveAlterations.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ActiveAlteration } from '../types/combat';
+import './ActiveAlterations.css';
+
+interface ActiveAlterationsProps {
+  alterations: ActiveAlteration[];
+}
+
+const ActiveAlterations: React.FC<ActiveAlterationsProps> = ({ alterations }) => {
+  if (!alterations || alterations.length === 0) return null;
+
+  return (
+    <div className="active-alterations">
+      {alterations.map((alt, idx) => (
+        <div
+          key={idx}
+          className={`alteration-badge ${alt.alteration.type}`}
+          title={`${alt.alteration.name} (${alt.remainingDuration !== null ? alt.remainingDuration : '∞'}t)`}
+        >
+          <span className="badge-icon">{alt.alteration.icon}</span>
+          {alt.stackCount > 1 && (
+            <span className="badge-stack">x{alt.stackCount}</span>
+          )}
+          {alt.remainingDuration !== null && (
+            <span className="badge-duration">{alt.remainingDuration}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ActiveAlterations;

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -5,6 +5,7 @@ import { CardInstance } from '../types/combat';
 import { PlayerBase } from '../types/player';
 import PlayerBaseComponent from './PlayerBase';
 import SynergyIndicator from './SynergyIndicator';
+import ActiveAlterations from './ActiveAlterations';
 import Hand from './Hand';
 import { gameConfigService } from '../utils/dataService';
 
@@ -143,6 +144,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
               <SynergyIndicator
                 effects={character.activeEffects.synergyEffect || []}
               />
+              <ActiveAlterations alterations={character.activeAlterations} />
             </div>
           ) : (
             <div className="empty-slot-text">Emplacement personnage</div>


### PR DESCRIPTION
## Summary
- show active buffs and debuffs on characters
- style alteration badges
- document the new feature in the technical docs and user guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853379a78ec832b8f4c7ead6d874a8e