### PR TITLE
Add simple AI simulation with difficulty levels

### DIFF
--- a/src/services/__tests__/aiTrainingService.test.ts
+++ b/src/services/__tests__/aiTrainingService.test.ts
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 jest.useFakeTimers();
 
 jest.mock('../../simulation/gameSimulator', () => ({
-  simulateGame: jest.fn(() => Promise.resolve({ winner: 'a', turns: 1 }))
+  simulateGame: jest.fn(() => Promise.resolve({ winner: 'a', turns: 1, log: [] }))
 }));
 
 import { aiTrainingService } from '../aiTrainingService';
@@ -40,3 +40,4 @@ describe('aiTrainingService', () => {
     expect((simulateGame as jest.Mock).mock.calls.length).toBe(1);
   });
 });
+

--- a/src/simulation/__tests__/aiAgent.test.ts
+++ b/src/simulation/__tests__/aiAgent.test.ts
@@ -1,0 +1,9 @@
+import { runAi } from '../aiAgent';
+
+describe('runAi', () => {
+  it('retourne le bon nombre dactions', () => {
+    const feedback = runAi(3, 'easy');
+    expect(feedback.actions).toHaveLength(3);
+  });
+});
+

--- a/src/simulation/__tests__/gameSimulator.test.ts
+++ b/src/simulation/__tests__/gameSimulator.test.ts
@@ -14,7 +14,10 @@ const { simulationResultsService: mockedService } = jest.requireMock('../../util
 
 describe('simulateGame', () => {
   it('enregistre le resultat dans simulationResultsService', async () => {
-    await simulateGame({ deckId: 'deck1', opponentDeckId: 'deck2' });
+    await simulateGame({ deckId: 'deck1', opponentDeckId: 'deck2', difficulty: 'easy' });
     expect(mockedService.create).toHaveBeenCalledTimes(1);
+    const args = mockedService.create.mock.calls[0][0] as any;
+    expect(args.metadata.difficulty).toBe('easy');
   });
 });
+

--- a/src/simulation/__tests__/loadTest.test.ts
+++ b/src/simulation/__tests__/loadTest.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 jest.mock('../gameSimulator', () => ({
-  simulateGame: jest.fn(() => Promise.resolve({ winner: 'a', turns: 1 }))
+  simulateGame: jest.fn(() => Promise.resolve({ winner: 'a', turns: 1, log: [] }))
 }));
 
 import { runLoadTest } from '../loadTest';
@@ -9,8 +9,9 @@ import { simulateGame } from '../gameSimulator';
 
 describe('runLoadTest', () => {
   it('appelle simulateGame le nombre requis de fois', async () => {
-    const result = await runLoadTest({ iterations: 5, deckId: 'a', opponentDeckId: 'b' });
+    const result = await runLoadTest({ iterations: 5, deckId: 'a', opponentDeckId: 'b', difficulty: 'medium' });
     expect((simulateGame as jest.Mock).mock.calls.length).toBe(5);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });
 });
+

--- a/src/simulation/aiAgent.ts
+++ b/src/simulation/aiAgent.ts
@@ -1,0 +1,27 @@
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export interface AiFeedback {
+  actions: string[];
+}
+
+/**
+ * Simule les actions de l'IA pour un nombre de tours donné.
+ * Les actions générées dépendent du niveau de difficulté.
+ */
+export function runAi(turns: number, difficulty: Difficulty = 'medium'): AiFeedback {
+  const actions: string[] = [];
+  const actionSets: Record<Difficulty, string[]> = {
+    easy: ['passe son tour', 'joue une carte faible', 'se défend'],
+    medium: ['attaque', 'lance un sort', 'se défend'],
+    hard: ['attaque agressivement', 'lance un sort puissant', 'optimise sa défense']
+  };
+
+  for (let t = 1; t <= turns; t++) {
+    const set = actionSets[difficulty];
+    const action = set[Math.floor(Math.random() * set.length)];
+    actions.push(`Tour ${t} : IA ${action}`);
+  }
+
+  return { actions };
+}
+

--- a/src/simulation/gameSimulator.ts
+++ b/src/simulation/gameSimulator.ts
@@ -1,5 +1,6 @@
 import { simulationResultsService } from '../utils/dataService';
 import type { Database } from '../types/database.types';
+import { runAi, Difficulty } from './aiAgent';
 
 export type SimulationType = 'training' | 'performance' | 'metrics';
 
@@ -7,11 +8,13 @@ export interface SimulationOptions {
   deckId: string;
   opponentDeckId: string;
   simulationType?: SimulationType;
+  difficulty?: Difficulty;
 }
 
 export interface SimulationResult {
   winner: string;
   turns: number;
+  log: string[];
 }
 
 /**
@@ -19,10 +22,19 @@ export interface SimulationResult {
  * Le vainqueur et le nombre de tours sont déterminés aléatoirement.
  * Le résultat est sauvegardé via simulationResultsService.create.
  */
-export async function simulateGame({ deckId, opponentDeckId, simulationType = 'training' }: SimulationOptions): Promise<SimulationResult> {
-  // Déterminer aléatoirement un nombre de tours et le gagnant
+export async function simulateGame({ deckId, opponentDeckId, simulationType = 'training', difficulty = 'medium' }: SimulationOptions): Promise<SimulationResult> {
+  // Déterminer aléatoirement un nombre de tours
   const turns = Math.floor(Math.random() * 10) + 1;
-  const winner = Math.random() > 0.5 ? deckId : opponentDeckId;
+
+  // Probabilité de victoire du deck principal selon la difficulté
+  let winChance = 0.5;
+  if (difficulty === 'easy') winChance = 0.7;
+  if (difficulty === 'hard') winChance = 0.3;
+
+  const winner = Math.random() < winChance ? deckId : opponentDeckId;
+
+  // Générer le feedback de l'IA
+  const aiFeedback = runAi(turns, difficulty);
 
   // Sauvegarder le résultat de la simulation
   await simulationResultsService.create({
@@ -30,8 +42,8 @@ export async function simulateGame({ deckId, opponentDeckId, simulationType = 't
     deck_id: deckId,
     opponent_deck_id: opponentDeckId,
     result: { won: winner === deckId, turns } as Database['public']['Tables']['simulation_results']['Row']['result'],
-    metadata: {}
+    metadata: { difficulty, actions: aiFeedback.actions }
   });
 
-  return { winner, turns };
+  return { winner, turns, log: aiFeedback.actions };
 }

--- a/src/simulation/loadTest.ts
+++ b/src/simulation/loadTest.ts
@@ -1,9 +1,12 @@
 import { simulateGame } from './gameSimulator';
 
+import type { Difficulty } from './aiAgent';
+
 export interface LoadTestOptions {
   iterations: number;
   deckId: string;
   opponentDeckId: string;
+  difficulty?: Difficulty;
 }
 
 export interface LoadTestResult {
@@ -16,10 +19,10 @@ export interface LoadTestResult {
  * @returns Durée totale en millisecondes
  */
 export async function runLoadTest(options: LoadTestOptions): Promise<LoadTestResult> {
-  const { iterations, deckId, opponentDeckId } = options;
+  const { iterations, deckId, opponentDeckId, difficulty } = options;
   const start = Date.now();
   for (let i = 0; i < iterations; i++) {
-    await simulateGame({ deckId, opponentDeckId, simulationType: 'performance' });
+    await simulateGame({ deckId, opponentDeckId, simulationType: 'performance', difficulty });
   }
   const durationMs = Date.now() - start;
   return { durationMs };


### PR DESCRIPTION
## Summary
- add `aiAgent` to generate AI actions by difficulty
- extend `simulateGame` to support difficulty levels and feedback log
- update load testing utilities
- adjust tests and add new coverage for AI agent

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859479f0808832b8a20ed48a2493a1b