### PR TITLE
Add game saves and mobile layout tweaks

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -329,6 +329,27 @@ CREATE INDEX idx_debug_logs_severity ON public.debug_logs(severity);
 -- Index pour optimiser les requêtes par date
 CREATE INDEX idx_debug_logs_created_at ON public.debug_logs(created_at);
 
+-- Table des sauvegardes de partie
+CREATE TABLE IF NOT EXISTS public.game_saves (
+    id bigserial PRIMARY KEY,
+    user_id uuid REFERENCES public.users(id) ON DELETE CASCADE,
+    state jsonb NOT NULL,
+    history jsonb NOT NULL DEFAULT '[]',
+    created_at timestamp with time zone DEFAULT timezone('utc'::text, now()),
+    updated_at timestamp with time zone DEFAULT timezone('utc'::text, now())
+);
+ALTER TABLE public.game_saves ENABLE ROW LEVEL SECURITY;
+CREATE POLICY all_access_game_saves ON public.game_saves FOR ALL USING (true) WITH CHECK (true);
+
+-- Trigger pour mettre à jour le timestamp de game_saves
+CREATE TRIGGER update_game_saves_updated_at
+    BEFORE UPDATE ON game_saves
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Index pour optimiser les requêtes par utilisateur
+CREATE INDEX idx_game_saves_user ON public.game_saves(user_id);
+
 -- Fonction pour nettoyer automatiquement les vieux logs
 CREATE OR REPLACE FUNCTION clean_old_logs()
 RETURNS void AS $$

--- a/src/components/GameBoardTest.css
+++ b/src/components/GameBoardTest.css
@@ -61,10 +61,16 @@
   .game-board-container {
     height: 80vh;
   }
-  
+
   .test-controls button {
     width: 100%;
     margin-right: 0;
+  }
+
+  .base-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 

--- a/src/components/GameBoardTest.tsx
+++ b/src/components/GameBoardTest.tsx
@@ -259,7 +259,7 @@ const GameBoardTest: React.FC = () => {
   };
 
   const Content: React.FC = () => {
-    const { state, nextPhase, nextTurn } = useGameEngine();
+    const { state, nextPhase, nextTurn, saveGame, loadGame, history } = useGameEngine();
 
     const turnActions = [
       { id: 'attack', label: 'Attaquer', cost: 2, onClick: () => console.log('Attaque') },
@@ -331,6 +331,9 @@ const GameBoardTest: React.FC = () => {
           }}>
             Infliger 15 dégâts à la base adverse
           </button>
+          <button onClick={() => saveGame('player1')}>Sauvegarder</button>
+          <button onClick={() => loadGame(1)}>Charger</button>
+          <p>Historique : {history.length} événements</p>
         </div>
       </div>
     </div>

--- a/src/components/TutorialOverlay.css
+++ b/src/components/TutorialOverlay.css
@@ -20,6 +20,17 @@
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
 }
 
+@media (max-width: 480px) {
+  .tutorial-box {
+    width: 90%;
+    padding: 1rem;
+  }
+  .tutorial-actions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
 .tutorial-actions {
   margin-top: 1rem;
   display: flex;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -244,6 +244,18 @@ export interface Database {
         Insert: Omit<Database['public']['Tables']['debug_logs']['Row'], 'id' | 'created_at'>
         Update: Partial<Database['public']['Tables']['debug_logs']['Insert']>
       }
+      game_saves: {
+        Row: {
+          id: number;
+          user_id: string;
+          state: Json;
+          history: Json;
+          created_at?: string;
+          updated_at?: string;
+        }
+        Insert: Omit<Database["public"]["Tables"]["game_saves"]["Row"], 'id' | 'created_at' | 'updated_at'>
+        Update: Partial<Database["public"]["Tables"]["game_saves"]["Insert"]>
+      },
     }
     Views: {
       [_ in never]: never

--- a/src/types/userTypes.ts
+++ b/src/types/userTypes.ts
@@ -54,4 +54,13 @@ export interface UserAchievement {
     user_id: string;
     achievement_id: number;
     unlocked_at: string;
-} 
+}
+
+export interface GameSave {
+    id: number;
+    user_id: string;
+    state: Json;
+    history: Json;
+    created_at: string;
+    updated_at: string;
+}

--- a/src/utils/dataService.ts
+++ b/src/utils/dataService.ts
@@ -520,3 +520,43 @@ export const debugLogsService = {
     };
   }
 };
+
+export const gameSaveService = {
+  async create(save: Omit<Database['public']['Tables']['game_saves']['Row'], 'id' | 'created_at' | 'updated_at'>): Promise<Database['public']['Tables']['game_saves']['Row']> {
+    const { data, error } = await supabase
+      .from('game_saves')
+      .insert(save)
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  },
+
+  async getById(id: number): Promise<Database['public']['Tables']['game_saves']['Row'] | null> {
+    const { data, error } = await supabase
+      .from('game_saves')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) throw error;
+    return data;
+  },
+
+  async getByUser(userId: string): Promise<Database['public']['Tables']['game_saves']['Row'][]> {
+    const { data, error } = await supabase
+      .from('game_saves')
+      .select('*')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false });
+    if (error) throw error;
+    return data;
+  },
+
+  async update(id: number, update: Partial<Database['public']['Tables']['game_saves']['Row']>) {
+    const { error } = await supabase
+      .from('game_saves')
+      .update(update)
+      .eq('id', id);
+    if (error) throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- create `game_saves` table for storing saved games
- add `gameSaveService` and types for save records
- expose save/load in `GameEngineContext`
- wire save/load controls in `GameBoardTest`
- improve mobile styles for tutorial and game board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685947acc49c832bada92968ec9aec3d