### PR TITLE
Add progress tracking service

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -329,6 +329,23 @@ CREATE INDEX idx_debug_logs_severity ON public.debug_logs(severity);
 -- Index pour optimiser les requêtes par date
 CREATE INDEX idx_debug_logs_created_at ON public.debug_logs(created_at);
 
+-- Table des statistiques des utilisateurs
+CREATE TABLE IF NOT EXISTS public.user_stats (
+    user_id uuid PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+    wins integer DEFAULT 0,
+    losses integer DEFAULT 0,
+    card_usage jsonb NOT NULL DEFAULT '{}',
+    updated_at timestamp with time zone DEFAULT timezone('utc'::text, now())
+);
+ALTER TABLE public.user_stats ENABLE ROW LEVEL SECURITY;
+CREATE POLICY all_access_user_stats ON public.user_stats FOR ALL USING (true) WITH CHECK (true);
+
+-- Trigger pour mettre à jour le timestamp de user_stats
+CREATE TRIGGER set_updated_at
+    BEFORE UPDATE ON user_stats
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
 -- Fonction pour nettoyer automatiquement les vieux logs
 CREATE OR REPLACE FUNCTION clean_old_logs()
 RETURNS void AS $$

--- a/src/services/__tests__/progressService.test.ts
+++ b/src/services/__tests__/progressService.test.ts
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals';
+import { progressService } from '../progressService';
+import { mockSupabase } from '../../tests/mocks/supabase';
+import { userService } from '../../utils/userService';
+
+const mockFrom = mockSupabase.from as jest.Mock;
+
+jest.mock('../../utils/userService', () => ({
+  userService: {
+    unlockAchievement: jest.fn()
+  }
+}));
+
+const selectBuilder = (data: any) => {
+  const single = jest.fn(async () => ({ data, error: null }));
+  const eq = jest.fn().mockReturnValue({ single });
+  const select = jest.fn().mockReturnValue({ eq, single });
+  return { select };
+};
+
+const upsertBuilder = (data: any) => {
+  const single = jest.fn(async () => ({ data, error: null }));
+  const select = jest.fn().mockReturnValue({ single });
+  const upsert = jest.fn().mockReturnValue({ select });
+  return { upsert };
+};
+
+describe('progressService.recordMatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates stats when none exist', async () => {
+    const sel = selectBuilder(null);
+    const up = upsertBuilder({ user_id: 'u1', wins: 1, losses: 0, card_usage: { '1': 1 } });
+    mockFrom
+      .mockReturnValueOnce({ select: sel.select })
+      .mockReturnValueOnce({ upsert: up.upsert });
+
+    const result = await progressService.recordMatch('u1', [1], true);
+
+    expect(result.wins).toBe(1);
+    expect(up.upsert).toHaveBeenCalled();
+    expect(userService.unlockAchievement).toHaveBeenCalledWith('u1', 1);
+  });
+
+  test('increments existing stats', async () => {
+    const sel = selectBuilder({ user_id: 'u1', wins: 2, losses: 0, card_usage: { '1': 1 } });
+    const up = upsertBuilder({ user_id: 'u1', wins: 3, losses: 0, card_usage: { '1': 2, '2': 1 } });
+    mockFrom
+      .mockReturnValueOnce({ select: sel.select })
+      .mockReturnValueOnce({ upsert: up.upsert });
+
+    const result = await progressService.recordMatch('u1', [1,2], true);
+
+    expect(result.wins).toBe(3);
+    expect(result.card_usage['1']).toBe(2);
+    expect(result.card_usage['2']).toBe(1);
+  });
+});

--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -1,0 +1,63 @@
+import { supabase } from '../utils/supabaseClient';
+import { userService } from '../utils/userService';
+
+export interface UserStats {
+  user_id: string;
+  wins: number;
+  losses: number;
+  card_usage: Record<string, number>;
+}
+
+const ACHIEVEMENT_THRESHOLDS = [
+  { wins: 1, id: 1 },
+  { wins: 10, id: 2 }
+];
+
+export const progressService = {
+  async getStats(userId: string): Promise<UserStats | null> {
+    const { data, error } = await supabase
+      .from('user_stats')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+    if (error || !data) return null;
+    return data as UserStats;
+  },
+
+  async recordMatch(userId: string, usedCards: number[], won: boolean): Promise<UserStats> {
+    const current =
+      (await this.getStats(userId)) || { user_id: userId, wins: 0, losses: 0, card_usage: {} };
+
+    if (won) current.wins += 1;
+    else current.losses += 1;
+
+    for (const id of usedCards) {
+      const key = id.toString();
+      current.card_usage[key] = (current.card_usage[key] || 0) + 1;
+    }
+
+    const { data, error } = await supabase
+      .from('user_stats')
+      .upsert({
+        user_id: userId,
+        wins: current.wins,
+        losses: current.losses,
+        card_usage: current.card_usage
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    await this.checkUnlocks(userId, data.wins);
+    return data as UserStats;
+  },
+
+  async checkUnlocks(userId: string, wins: number): Promise<void> {
+    for (const a of ACHIEVEMENT_THRESHOLDS) {
+      if (wins >= a.wins) {
+        await userService.unlockAchievement(userId, a.id);
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- support user stats table to store wins, losses and card usage
- implement `progressService` to record match results and unlock achievements
- add unit tests for progress tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685947ae8940832b9be4853049c53b05