### PR TITLE
Refactor card creation as service

### DIFF
--- a/src/services/__tests__/cardCreationService.test.ts
+++ b/src/services/__tests__/cardCreationService.test.ts
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+import cardCreationService, { PartialCardInput } from '../cardCreationService';
+import { mockSupabase } from '../../tests/mocks/supabase';
+
+const mockFrom = mockSupabase.from as jest.Mock;
+
+function setupInsert(returnData: any, isError = false) {
+  const single = jest.fn().mockImplementation(() => Promise.resolve({ data: returnData, error: isError ? returnData : null }));
+  const select = jest.fn().mockReturnValue({ single });
+  const insert = jest.fn().mockReturnValue({ select });
+  mockFrom.mockReturnValue({ insert });
+  return { insert, select, single };
+}
+
+describe('cardCreationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates card and keeps wip when mandatory fields missing', async () => {
+    const input: PartialCardInput = { name: 'Test', type: 'personnage', properties: {} };
+    const expected = { id: 1, name: 'Test', type: 'personnage', is_wip: true };
+    setupInsert(expected);
+
+    const result = await cardCreationService.create(input);
+    expect(mockFrom).toHaveBeenCalledWith('cards');
+    expect(result.is_wip).toBe(true);
+  });
+
+  test('creates card without wip when fields complete', async () => {
+    const input: PartialCardInput = { name: 'Ok', type: 'personnage', rarity: 'banger', properties: { health: 5 }, is_wip: false };
+    const expected = { id: 2, name: 'Ok', type: 'personnage', rarity: 'banger', properties: { health: 5 }, is_wip: false };
+    setupInsert(expected);
+
+    const result = await cardCreationService.create(input);
+    expect(result.is_wip).toBe(false);
+  });
+});

--- a/src/services/cardCreationService.ts
+++ b/src/services/cardCreationService.ts
@@ -1,0 +1,73 @@
+import { supabase } from '../utils/supabaseClient';
+import { Card } from '../types';
+
+/**
+ * Partial card data used for creation or update operations.
+ */
+export type PartialCardInput = Partial<Omit<Card, 'id'>> & {
+  id?: number;
+};
+
+/**
+ * Determine if a card has all mandatory fields filled.
+ * Currently name, type and rarity are considered required.
+ */
+function isComplete(card: PartialCardInput): boolean {
+  if (!card.name || !card.type || !card.rarity) return false;
+  if (card.type === 'personnage' && (!card.properties || card.properties.health === undefined)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Normalize card fields for the database (snake_case).
+ */
+function formatForDB(card: PartialCardInput) {
+  const { eventDuration, ...rest } = card;
+  return { ...rest, event_duration: eventDuration };
+}
+
+export const cardCreationService = {
+  /**
+   * Create a new card in the database. Missing required fields mark the card as WIP.
+   */
+  async create(card: PartialCardInput): Promise<Card> {
+    const complete = isComplete(card);
+    const insertData = formatForDB({
+      is_wip: complete ? card.is_wip ?? false : true,
+      is_crap: card.is_crap ?? false,
+      properties: card.properties || {},
+      ...card,
+    });
+    const { data, error } = await supabase
+      .from('cards')
+      .insert(insertData)
+      .select()
+      .single();
+    if (error) throw error;
+    return { ...(data as any), eventDuration: (data as any).event_duration } as Card;
+  },
+
+  /**
+   * Update an existing card. If required fields become missing, it stays flagged as WIP.
+   */
+  async update(id: number, updates: PartialCardInput): Promise<Card> {
+    const complete = isComplete(updates);
+    const updateData = formatForDB({
+      ...updates,
+      is_wip: complete ? updates.is_wip ?? false : true,
+    });
+    Object.keys(updateData).forEach((k) => (updateData as any)[k] === undefined && delete (updateData as any)[k]);
+    const { data, error } = await supabase
+      .from('cards')
+      .update(updateData)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) throw error;
+    return { ...(data as any), eventDuration: (data as any).event_duration } as Card;
+  },
+};
+
+export default cardCreationService;


### PR DESCRIPTION
## Summary
- add `cardCreationService` for ergonomic card creation
- include tests for the new service

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884e421df8c832b9c1f942829d4375e