### PR TITLE
Add simple card creator interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import Achievements from './components/Achievements';
 import InventoryPage from './components/InventoryPage';
 import BoosterOpening from './components/BoosterOpening';
 import DeckBuilder from './components/DeckBuilder';
+import CardCreator from './components/CardCreator';
 import { supabase } from './utils/supabaseClient';
 
 // Import de nos nouveaux composants UI
@@ -431,6 +432,9 @@ const AppContent: React.FC = () => {
                 <button className="btn btn-primary btn-lg" onClick={() => navigate('/cards')}>
                   Éditer une carte
                 </button>
+                <button className="btn btn-outline btn-lg" onClick={() => navigate('/create-card')}>
+                  Nouvelle carte
+                </button>
                 <button className="btn btn-outline btn-lg" onClick={() => navigate('/browser')}>
                   Parcourir les cartes
                 </button>
@@ -523,9 +527,12 @@ const AppContent: React.FC = () => {
               onSpellIdsChange={setSpellIds}
               onTagIdsChange={setTagIds}
             />
-          </div>
-        } />
-        
+        </div>
+      } />
+
+        {/* Création rapide de carte */}
+        <Route path="/create-card" element={<CardCreator />} />
+
         {/* Explorateur de cartes */}
         <Route path="/browser" element={
           <CardBrowser

--- a/src/components/CardCreator.tsx
+++ b/src/components/CardCreator.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import cardCreationService, { PartialCardInput } from '../services/cardCreationService';
+
+const defaultCard: PartialCardInput = {
+  name: '',
+  type: 'personnage',
+  rarity: 'gros_bodycount',
+  properties: {}
+};
+
+const CardCreator: React.FC = () => {
+  const [card, setCard] = useState<PartialCardInput>(defaultCard);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value, type, checked } = e.target;
+    if (name === 'health') {
+      setCard((prev) => ({
+        ...prev,
+        properties: { ...prev.properties, health: Number(value) }
+      }));
+    } else if (type === 'checkbox') {
+      setCard((prev) => ({ ...prev, [name]: checked }));
+    } else {
+      setCard((prev) => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const created = await cardCreationService.create(card);
+      setStatus(`Carte créée: ID ${created.id}${created.is_wip ? ' (WIP)' : ''}`);
+      setCard(defaultCard);
+    } catch (err) {
+      console.error('Erreur création carte', err);
+      setStatus('Erreur lors de la création');
+    }
+  };
+
+  return (
+    <form className="card-creator" onSubmit={handleSubmit}>
+      <h2>Création rapide de carte</h2>
+      <div>
+        <label>Nom</label>
+        <input name="name" value={card.name || ''} onChange={handleChange} required />
+      </div>
+      <div>
+        <label>Type</label>
+        <select name="type" value={card.type} onChange={handleChange}>
+          <option value="personnage">Personnage</option>
+          <option value="objet">Objet</option>
+          <option value="evenement">Évènement</option>
+          <option value="lieu">Lieu</option>
+          <option value="action">Action</option>
+        </select>
+      </div>
+      {card.type === 'personnage' && (
+        <div>
+          <label>PV</label>
+          <input
+            type="number"
+            name="health"
+            value={card.properties?.health ?? ''}
+            onChange={handleChange}
+          />
+        </div>
+      )}
+      {card.type === 'evenement' && (
+        <div>
+          <label>Durée</label>
+          <select
+            name="eventDuration"
+            value={card.eventDuration || ''}
+            onChange={handleChange}
+          >
+            <option value="">--</option>
+            <option value="instantanee">Instantanée</option>
+            <option value="temporaire">Temporaire</option>
+            <option value="permanente">Permanente</option>
+          </select>
+        </div>
+      )}
+      <div>
+        <label>Rareté</label>
+        <select name="rarity" value={card.rarity} onChange={handleChange}>
+          <option value="gros_bodycount">Gros Bodycount</option>
+          <option value="interessant">Intéressant</option>
+          <option value="banger">Banger</option>
+          <option value="cheate">Cheaté</option>
+        </select>
+      </div>
+      <div>
+        <label>Description</label>
+        <textarea name="description" value={card.description || ''} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Image</label>
+        <input name="image" value={card.image || ''} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Effet passif</label>
+        <textarea
+          name="passive_effect"
+          value={card.passive_effect || ''}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            name="is_crap"
+            checked={card.is_crap ?? false}
+            onChange={handleChange}
+          />
+          Carte poubelle
+        </label>
+      </div>
+      <button type="submit">Créer</button>
+      {status && <p className="status-message">{status}</p>}
+    </form>
+  );
+};
+
+export default CardCreator;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,3 +24,4 @@ export { default as DeckBuilder } from "./DeckBuilder";
 export { default as TurnTracker } from "./TurnTracker";
 export { default as CharismeDisplay } from "./CharismeDisplay";
 export { InfoTooltip } from "./ui";
+export { default as CardCreator } from "./CardCreator";

--- a/src/services/__tests__/cardCreationService.test.ts
+++ b/src/services/__tests__/cardCreationService.test.ts
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+import cardCreationService, { PartialCardInput } from '../cardCreationService';
+import { mockSupabase } from '../../tests/mocks/supabase';
+
+const mockFrom = mockSupabase.from as jest.Mock;
+
+function setupInsert(returnData: any, isError = false) {
+  const single = jest.fn().mockImplementation(() => Promise.resolve({ data: returnData, error: isError ? returnData : null }));
+  const select = jest.fn().mockReturnValue({ single });
+  const insert = jest.fn().mockReturnValue({ select });
+  mockFrom.mockReturnValue({ insert });
+  return { insert, select, single };
+}
+
+describe('cardCreationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates card and keeps wip when mandatory fields missing', async () => {
+    const input: PartialCardInput = { name: 'Test', type: 'personnage', properties: {} };
+    const expected = { id: 1, name: 'Test', type: 'personnage', is_wip: true };
+    setupInsert(expected);
+
+    const result = await cardCreationService.create(input);
+    expect(mockFrom).toHaveBeenCalledWith('cards');
+    expect(result.is_wip).toBe(true);
+  });
+
+  test('creates card without wip when fields complete', async () => {
+    const input: PartialCardInput = { name: 'Ok', type: 'personnage', rarity: 'banger', properties: { health: 5 }, is_wip: false };
+    const expected = { id: 2, name: 'Ok', type: 'personnage', rarity: 'banger', properties: { health: 5 }, is_wip: false };
+    setupInsert(expected);
+
+    const result = await cardCreationService.create(input);
+    expect(result.is_wip).toBe(false);
+  });
+});

--- a/src/services/cardCreationService.ts
+++ b/src/services/cardCreationService.ts
@@ -1,0 +1,73 @@
+import { supabase } from '../utils/supabaseClient';
+import { Card } from '../types';
+
+/**
+ * Partial card data used for creation or update operations.
+ */
+export type PartialCardInput = Partial<Omit<Card, 'id'>> & {
+  id?: number;
+};
+
+/**
+ * Determine if a card has all mandatory fields filled.
+ * Currently name, type and rarity are considered required.
+ */
+function isComplete(card: PartialCardInput): boolean {
+  if (!card.name || !card.type || !card.rarity) return false;
+  if (card.type === 'personnage' && (!card.properties || card.properties.health === undefined)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Normalize card fields for the database (snake_case).
+ */
+function formatForDB(card: PartialCardInput) {
+  const { eventDuration, ...rest } = card;
+  return { ...rest, event_duration: eventDuration };
+}
+
+export const cardCreationService = {
+  /**
+   * Create a new card in the database. Missing required fields mark the card as WIP.
+   */
+  async create(card: PartialCardInput): Promise<Card> {
+    const complete = isComplete(card);
+    const insertData = formatForDB({
+      is_wip: complete ? card.is_wip ?? false : true,
+      is_crap: card.is_crap ?? false,
+      properties: card.properties || {},
+      ...card,
+    });
+    const { data, error } = await supabase
+      .from('cards')
+      .insert(insertData)
+      .select()
+      .single();
+    if (error) throw error;
+    return { ...(data as any), eventDuration: (data as any).event_duration } as Card;
+  },
+
+  /**
+   * Update an existing card. If required fields become missing, it stays flagged as WIP.
+   */
+  async update(id: number, updates: PartialCardInput): Promise<Card> {
+    const complete = isComplete(updates);
+    const updateData = formatForDB({
+      ...updates,
+      is_wip: complete ? updates.is_wip ?? false : true,
+    });
+    Object.keys(updateData).forEach((k) => (updateData as any)[k] === undefined && delete (updateData as any)[k]);
+    const { data, error } = await supabase
+      .from('cards')
+      .update(updateData)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) throw error;
+    return { ...(data as any), eventDuration: (data as any).event_duration } as Card;
+  },
+};
+
+export default cardCreationService;


### PR DESCRIPTION
## Summary
- introduce `CardCreator` component for quick card creation
- export the component and route it via `/create-card`
- add button on home page for easy access

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884e421df8c832b9c1f942829d4375e